### PR TITLE
In MessageTest, modified as not depend on execution order of test case. #107

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 .DS_Store
 evidence
 log
+*.iml

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/message/MessageTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/message/MessageTest.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.functionaltest.app.message;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -30,6 +31,11 @@ import org.terasoluna.gfw.functionaltest.app.FunctionTestSupport;
 public class MessageTest extends FunctionTestSupport {
 
     public MessageTest() {
+    }
+
+    @Before
+    public void setupDefaultLanguage(){
+        driver.findElement(By.id("English")).click();
     }
 
     @Test
@@ -621,7 +627,6 @@ public class MessageTest extends FunctionTestSupport {
 
     @Test
     public void test07_04_outputMessage() {
-        driver.findElement(By.id("English")).click();
         driver.findElement(By.id("outputMessage_07_04")).click();
 
         // div ul li Tag confirm


### PR DESCRIPTION
Please review #107 , and merge to master branch.

**[Note]**
I have tested under the following environment because not support spring-security 3.2 as test application.
- spring-security version change to 3.1.4.RELEASE(revert to 3.1.4.RELEASE on local)
- terasoluna-gfw-security-web version change to 1.0.1.RELEASE(revert to 1.0.1.RELEASE on local)
