### PR TITLE
avoid calling oracleVersionRetriever#getVersion in case of PostgreSQL #164

### DIFF
--- a/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/domain/service/queryescape/AbstractDatabaseMetaInfoService.java
+++ b/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/domain/service/queryescape/AbstractDatabaseMetaInfoService.java
@@ -42,6 +42,8 @@ public abstract class AbstractDatabaseMetaInfoService implements
     @PostConstruct
     public void init() {
         this.databaseId = getDatabaseIdInternal();
-        this.oracleVersion = oracleVersionRetriever.getVersion();
+        if ("oracle".equalsIgnoreCase(this.databaseId)) {
+            this.oracleVersion = oracleVersionRetriever.getVersion();
+        }
     }
 }


### PR DESCRIPTION
Changed to call `OracleVersionRetriever#getVersion` only in case of Oracle #164