### PR TITLE
add a dependency env to taglibs-standard-jstlel, and remove dependency domain to env #301

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script:
   - mvn -U sql:execute -f terasoluna-gfw-functionaltest-initdb/pom.xml
   - mvn -U install -f terasoluna-gfw-functionaltest-env/pom.xml -P tomcat8-postgresql
   - mvn -U install -f terasoluna-gfw-functionaltest-domain/pom.xml
-  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,include-jstlel,travis
+  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,warpack-jstlel,travis
   - mvn -U test -f terasoluna-gfw-functionaltest-selenium/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script:
   - mvn -U sql:execute -f terasoluna-gfw-functionaltest-initdb/pom.xml
   - mvn -U install -f terasoluna-gfw-functionaltest-env/pom.xml -P tomcat8-postgresql
   - mvn -U install -f terasoluna-gfw-functionaltest-domain/pom.xml
-  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,warpack-jstlel,travis
+  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,warpack-jstl,travis
   - mvn -U test -f terasoluna-gfw-functionaltest-selenium/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script:
   - mvn -U sql:execute -f terasoluna-gfw-functionaltest-initdb/pom.xml
   - mvn -U install -f terasoluna-gfw-functionaltest-env/pom.xml -P tomcat8-postgresql
   - mvn -U install -f terasoluna-gfw-functionaltest-domain/pom.xml
-  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,travis
+  - mvn -U install cargo:daemon-start -f terasoluna-gfw-functionaltest-web/pom.xml -P warpack-env,include-jstlel,travis
   - mvn -U test -f terasoluna-gfw-functionaltest-selenium/pom.xml

--- a/terasoluna-gfw-functionaltest-web/pom.xml
+++ b/terasoluna-gfw-functionaltest-web/pom.xml
@@ -24,6 +24,11 @@
                     <groupId>${project.groupId}</groupId>
                     <artifactId>terasoluna-gfw-functionaltest-env</artifactId>
                 </dependency>
+                <!-- Add for local (Tomcat or Tc Server)  -->
+                <dependency>
+                    <groupId>org.apache.taglibs</groupId>
+                    <artifactId>taglibs-standard-jstlel</artifactId>
+                </dependency>
             </dependencies>
         </profile>
         <profile>
@@ -40,11 +45,9 @@
                 </dependency>
             </dependencies>
         </profile>
+        <!-- Add profile for packaging JSTL jars -->
         <profile>
-            <id>include-jstlel</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <id>warpack-jstl</id>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.taglibs</groupId>

--- a/terasoluna-gfw-functionaltest-web/pom.xml
+++ b/terasoluna-gfw-functionaltest-web/pom.xml
@@ -40,6 +40,18 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>include-jstlel</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.taglibs</groupId>
+                    <artifactId>taglibs-standard-jstlel</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>


### PR DESCRIPTION
Please review #301.

The reason you have removed the dependency to env from domain is domain is not depend env's classes and dependency at all. web multi blank project as well (domain is not depend env).