### PR TITLE
Add the version and type in the description of the dependency #425

### DIFF
--- a/terasoluna-gfw-functionaltest-domain/pom.xml
+++ b/terasoluna-gfw-functionaltest-domain/pom.xml
@@ -31,14 +31,20 @@
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>
             <artifactId>terasoluna-gfw-security-core</artifactId>
+            <version>${terasoluna.gfw.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>
             <artifactId>terasoluna-gfw-jpa</artifactId>
+            <version>${terasoluna.gfw.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>
             <artifactId>terasoluna-gfw-mybatis3</artifactId>
+            <version>${terasoluna.gfw.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>

--- a/terasoluna-gfw-functionaltest-env/pom.xml
+++ b/terasoluna-gfw-functionaltest-env/pom.xml
@@ -132,6 +132,8 @@
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>
             <artifactId>terasoluna-gfw-jpa</artifactId>
+            <version>${terasoluna.gfw.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.terasoluna.gfw</groupId>


### PR DESCRIPTION
Please review #425 .

## Issue Link
 - terasoluna-gfw 「[Packaging type of artifacts without java files should be pom #519](https://github.com/terasolunaorg/terasoluna-gfw/issues/519)」

