### PR TITLE
exclude JBoss modules which conflict with the libraries in the war file #507

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,8 +5,11 @@
 			<module name="org.hibernate.validator" />
 			<module name="javax.inject.api" />
 			<module name="javax.validation.api" />
-			<module name="org.javassist" />
 			<module name="org.jboss.logging" />
 		</exclusions>
+		<exclude-subsystems>
+			<subsystem name="jpa" />
+			<subsystem name="jaxrs" />
+		</exclude-subsystems>
 	</deployment>
 </jboss-deployment-structure>

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,18 +1,7 @@
 <jboss-deployment-structure>
 	<deployment>
 		<exclusions>
-			<module name="javaee.api" />
-			<module name="org.hibernate.validator" />
 			<module name="org.slf4j" />
-			<module name="org.apache.commons.logging" />
 		</exclusions>
-		<dependencies>
-			<module name="javax.servlet.api" />
-			<module name="javax.servlet.jsp.api" />
-			<module name="javax.annotation.api" />
-		</dependencies>
-		<exclude-subsystems>
-			<subsystem name="jpa" />
-		</exclude-subsystems>
 	</deployment>
 </jboss-deployment-structure>

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,6 +2,11 @@
 	<deployment>
 		<exclusions>
 			<module name="org.slf4j" />
+			<module name="org.hibernate.validator" />
+			<module name="javax.inject.api" />
+			<module name="javax.validation.api" />
+			<module name="org.javassist" />
+			<module name="org.jboss.logging" />
 		</exclusions>
 	</deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Please review #507 .

JBoss modules : org.slf4j, org.apache.commons.logging, org.hibernate.validator, javax.inject.api, javax.validation.api, org.javassist and org.jboss.logging conflict with the libraries in the war file.