### PR TITLE
Exclude jboss-logging module #507

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -6,6 +6,7 @@
 			<module name="org.hibernate.validator" />
 			<module name="org.slf4j" />
 			<module name="org.apache.commons.logging" />
+			<module name="org.jboss.logging" />
 		</exclusions>
 		<dependencies>
 			<module name="javax.servlet.api" />


### PR DESCRIPTION
In 5.3.0.RC1, the test has failed because of conflicting jboss-logging library in war file with the one in the modlue of JBoss6.
Then, I have excluded jboss-logging module from a deployment.
Please review #507.
