### PR TITLE
optimize jboss6 module structure #545

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,12 +5,10 @@
 			<module name="javax.faces.api" />
 			<module name="org.hibernate.validator" />
 			<module name="org.slf4j" />
-			<module name="org.apache.commons.logging" />
 			<module name="org.jboss.logging" />
+			<module name="javax.inject.api" />
 		</exclusions>
 		<dependencies>
-			<module name="javax.servlet.api" />
-			<module name="javax.servlet.jsp.api" />
 			<module name="javax.annotation.api" />
 		</dependencies>
 		<exclude-subsystems>


### PR DESCRIPTION
Please review #545.
I have compared the libraries in the war file with JBoss6 modules which are read when the war file is deployed.
Then, I found that javax.inject.api module is conflicted and a few settings are unnecessary (concretely, org.apache.commons.logging, javax.servlet.api, javax.servlet.jsp.api modules should be removed in jboss-deployment-structure.xml file).