### PR TITLE
[5.1.x] optimize jboss6 module structure #584

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,11 +5,10 @@
 			<module name="javax.faces.api" />
 			<module name="org.hibernate.validator" />
 			<module name="org.slf4j" />
-			<module name="org.apache.commons.logging" />
+			<module name="org.jboss.logging" />
+			<module name="javax.inject.api" />
 		</exclusions>
 		<dependencies>
-			<module name="javax.servlet.api" />
-			<module name="javax.servlet.jsp.api" />
 			<module name="javax.annotation.api" />
 		</dependencies>
 		<exclude-subsystems>


### PR DESCRIPTION
Please review #584.

The liberaries structure in the war file in 5.1.x is also most of same as one in 5.3.x.
Therefore, no need to change jboss-deployment-structure.xml file.
 I tested this branch and verified the result was ok.

(cherry picked from commit 45da47b7db605c08d951ed42a9d63a58b4e0050d)


