### PR TITLE
recognize ap server #605

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=interstage
 application.server.version=11

--- a/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=interstage
+application.server.version=11

--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=jboss
+application.server.version=6

--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=jboss
 application.server.version=6

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=jboss
+application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=jboss
 application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=8.5

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=8.5

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=tomcat
+application.server.version=8.5

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=tomcat
 application.server.version=8.5

--- a/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=weblogic
 application.server.version=12

--- a/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=weblogic
+application.server.version=12

--- a/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+application.server.name=webotx
+application.server.version=9

--- a/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 application.server.name=webotx
 application.server.version=9

--- a/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=System Error...
+application.server.name=webspherelp
+application.server.version=16

--- a/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=System Error...
 application.server.name=webspherelp
 application.server.version=16

--- a/terasoluna-gfw-functionaltest-env/configs/webspheretr-db2/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webspheretr-db2/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=System Error...
+application.server.name=webspheretr
+application.server.version=9

--- a/terasoluna-gfw-functionaltest-env/configs/webspheretr-db2/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/webspheretr-db2/resources/META-INF/spring/application-env.properties
@@ -1,4 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=System Error...
 application.server.name=webspheretr
 application.server.version=9

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
@@ -1,5 +1,4 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-app.redirect.pageTitle.404Error=Page Not Found
 ## application server name and version properties are used in order to
 ## change the assertions in test which depends on application server.
 ## when the new profile is added, set appropriate values.

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,7 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
 app.redirect.pageTitle.404Error=Page Not Found
+## application server name and version properties are used in order to
+## change the assertions in test which depends on application server.
+## when the new profile is added, set appropriate values.
+application.server.name=tomcat
+application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -1,0 +1,12 @@
+package org.terasoluna.gfw.functionaltest.app;
+
+/**
+ * Enumeration class for identifying application server.
+ * <p>
+ * If application server name is not set in application.env.properties, <br/>
+ * UNKNOWN is set.
+ * </p>
+ */
+public enum ApServerName {
+	UNKNOWN, INTERSTAGE, JBOSS, TOMCAT, WEBLOGIC, WEBOTX, WEBSPHERELP, WEBSPHERETR
+}

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -18,10 +18,9 @@ package org.terasoluna.gfw.functionaltest.app;
 /**
  * Enumeration class for identifying application server.
  * <p>
- * If application server name is not set in application-env.properties,
- * {@code UNKNOWN} is set.
+ * If application server name is not set in application-env.properties, {@code UNKNOWN} is set.
  * </p>
  */
 public enum ApServerName {
-	UNKNOWN, INTERSTAGE, JBOSS, TOMCAT, WEBLOGIC, WEBOTX, WEBSPHERELP, WEBSPHERETR
+    UNKNOWN, INTERSTAGE, JBOSS, TOMCAT, WEBLOGIC, WEBOTX, WEBSPHERELP, WEBSPHERETR
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2013-2017 NTT DATA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.terasoluna.gfw.functionaltest.app;
 
 /**
  * Enumeration class for identifying application server.
  * <p>
- * If application server name is not set in application.env.properties, <br/>
- * UNKNOWN is set.
+ * If application server name is not set in application-env.properties,
+ * {@code UNKNOWN} is set.
  * </p>
  */
 public enum ApServerName {

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -48,15 +48,6 @@ public class WebDriverOperations {
     }
 
     /**
-     * Get the text (display value) set for the specified element.
-     * @param by Identifier to look for elements
-     * @return And returns the text (display value)
-     */
-    public String getText(By by) {
-    	return webDriver.findElement(by).getText();
-    }
-
-    /**
      * Check the specified element exists.
      * @param by Identifier to look for elements
      * @return And returns true if the specified element is present.
@@ -95,7 +86,7 @@ public class WebDriverOperations {
      * @return application server name
      */
     public ApServerName getApServerName() {
-        String serverName = getText(By.id("apServerName")).toUpperCase();
+        String serverName = webDriver.findElement(By.id("apServerName")).getText().toUpperCase();
         try {
     	    return ApServerName.valueOf(serverName);
         } catch (IllegalArgumentException e) {
@@ -110,6 +101,6 @@ public class WebDriverOperations {
      * @return application server version
      */
     public String getApServerVersion() {
-    	return getText(By.id("apServerVersion"));
+        return webDriver.findElement(By.id("apServerVersion")).getText();
     }
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class that provides a (logic for WebDriver) browser operation.
@@ -29,6 +31,8 @@ public class WebDriverOperations {
     protected final WebDriver webDriver;
 
     protected long defaultTimeoutSecForImplicitlyWait = 5;
+
+    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
 
     public WebDriverOperations(WebDriver webDriver) {
         this.webDriver = webDriver;
@@ -41,6 +45,15 @@ public class WebDriverOperations {
     public void setDefaultTimeoutForImplicitlyWait(
             long defaultTimeoutSecForImplicitlyWait) {
         this.defaultTimeoutSecForImplicitlyWait = defaultTimeoutSecForImplicitlyWait;
+    }
+
+    /**
+     * Get the text (display value) set for the specified element.
+     * @param by Identifier to look for elements
+     * @return And returns the text (display value)
+     */
+    public String getText(By by) {
+    	return webDriver.findElement(by).getText();
     }
 
     /**
@@ -75,5 +88,28 @@ public class WebDriverOperations {
      */
     public void setTimeoutForImplicitlyWait(long timeout, TimeUnit timeUnit) {
         webDriver.manage().timeouts().implicitlyWait(timeout, timeUnit);
+    }
+
+    /**
+     * Get application server name.
+     * @return application server name
+     */
+    public ApServerName getApServerName() {
+        String serverName = getText(By.id("apServerName")).toUpperCase();
+        try {
+    	    return ApServerName.valueOf(serverName);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Unkown application server name:{} is detected.", serverName);
+            // If server name not defined in the ApServerName class, set it to UNKNOWN.
+            return ApServerName.UNKNOWN;
+        }
+    }
+
+    /**
+     * Get application server version.
+     * @return application server version
+     */
+    public String getApServerVersion() {
+    	return getText(By.id("apServerVersion"));
     }
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
  */
 public class WebDriverOperations {
 
+    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
+
     protected final WebDriver webDriver;
 
     protected long defaultTimeoutSecForImplicitlyWait = 5;
-
-    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
 
     public WebDriverOperations(WebDriver webDriver) {
         this.webDriver = webDriver;

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -28,7 +28,8 @@ import org.slf4j.LoggerFactory;
  */
 public class WebDriverOperations {
 
-    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
+    private static final Logger logger = LoggerFactory
+            .getLogger(WebDriverOperations.class);
 
     protected final WebDriver webDriver;
 
@@ -86,11 +87,13 @@ public class WebDriverOperations {
      * @return application server name
      */
     public ApServerName getApServerName() {
-        String serverName = webDriver.findElement(By.id("apServerName")).getText().toUpperCase();
+        String serverName = webDriver.findElement(By.id("apServerName"))
+                .getText().toUpperCase();
         try {
-    	    return ApServerName.valueOf(serverName);
+            return ApServerName.valueOf(serverName);
         } catch (IllegalArgumentException e) {
-            logger.warn("Unkown application server name:{} is detected.", serverName);
+            logger.warn("Unkown application server name:{} is detected.",
+                    serverName);
             // If server name not defined in the ApServerName class, set it to UNKNOWN.
             return ApServerName.UNKNOWN;
         }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/logging/LoggingTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/logging/LoggingTest.java
@@ -50,7 +50,7 @@ public class LoggingTest extends FunctionTestSupport {
 
         // cut x-Track MDC
         String targetMdc = driver.findElement(By.id("xTrackMDC")).getText();
-        String footerMdc = driver.findElement(By.cssSelector("p")).getText();
+        String footerMdc = driver.findElement(By.id("xtrack")).getText();
         footerMdc = footerMdc.substring(footerMdc.indexOf(":") + 1, footerMdc
                 .indexOf(":") + 33);
         // check default x-Track MDC
@@ -67,7 +67,7 @@ public class LoggingTest extends FunctionTestSupport {
 
         // cut x-Track MDC
         String targetMdc = driver.findElement(By.id("xTrackMDC")).getText();
-        String footerMdc = driver.findElement(By.cssSelector("p")).getText();
+        String footerMdc = driver.findElement(By.id("xtrack")).getText();
         footerMdc = footerMdc.substring(footerMdc.indexOf(":") + 1, footerMdc
                 .indexOf(":") + 33);
         // check custom x-Track MDC

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
@@ -107,10 +107,9 @@ public class RedirectTest extends FunctionTestSupport {
 
         driver.findElement(By.id("btn1")).click();
 
-        String expectedErrorMessage;
-
         // Unlike other application servers, WebSphere Liberty Profile & WebSphere traditional wraps an unexpected exception of ServletException.
         // So the expected error page is different.
+        String expectedErrorMessage;
         if (apServerName == ApServerName.WEBSPHERELP || apServerName == ApServerName.WEBSPHERETR) {
         	expectedErrorMessage = "System Error...";
         } else {

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
@@ -109,7 +109,7 @@ public class RedirectTest extends FunctionTestSupport {
 
         String expectedErrorMessage;
 
-        // Unlike other application servers, WebSphere Liberty Profile 16 & WebSphere traditional 9 wraps an unexpected exception of ServletException.
+        // Unlike other application servers, WebSphere Liberty Profile & WebSphere traditional wraps an unexpected exception of ServletException.
         // So the expected error page is different.
         if (apServerName == ApServerName.WEBSPHERELP || apServerName == ApServerName.WEBSPHERETR) {
         	expectedErrorMessage = "System Error...";

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.terasoluna.gfw.functionaltest.app.ApServerName;
 import org.terasoluna.gfw.functionaltest.app.FunctionTestSupport;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -33,9 +34,6 @@ public class RedirectTest extends FunctionTestSupport {
 
     @Value("${app.redirect.allowed.externalUrl}")
     String redirectionAllowedExternalUrl;
-
-    @Value("${app.redirect.pageTitle.404Error}")
-    String pageTitle404Error;
 
     @Test
     public void test01_01_redirectToValidInternalLink() {
@@ -105,12 +103,22 @@ public class RedirectTest extends FunctionTestSupport {
         // screen capture
         screenCapture.save(driver);
 
+        ApServerName apServerName = webDriverOperations.getApServerName();
+        String apServerVersion = webDriverOperations.getApServerVersion();
+
         driver.findElement(By.id("btn1")).click();
 
+        // Unlike other application servers, WebSphere Liberty Profile 16 & WebSphere traditional 9 wraps an unexpected exception of ServletException.
+        // So the expected error page is different.
         // confirms that 404 error occurred after login transition
-        assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
-                is(pageTitle404Error));
-
+        if (apServerName == ApServerName.WEBSPHERELP && "16".equals(apServerVersion)
+                || apServerName == ApServerName.WEBSPHERETR && "9".equals(apServerVersion)) {
+            assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
+                    is("System Error..."));
+        } else {
+            assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
+                    is("Page Not Found"));
+        }
     }
 
     @Test

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
@@ -89,6 +89,8 @@ public class RedirectTest extends FunctionTestSupport {
     @Test
     public void test01_03_redirectToExternalLink() {
 
+    	ApServerName apServerName = webDriverOperations.getApServerName();
+
         driver.findElement(By.id("listWithExternalPath")).click();
         driver.findElement(By.id("btn1")).click();
 
@@ -103,22 +105,21 @@ public class RedirectTest extends FunctionTestSupport {
         // screen capture
         screenCapture.save(driver);
 
-        ApServerName apServerName = webDriverOperations.getApServerName();
-        String apServerVersion = webDriverOperations.getApServerVersion();
-
         driver.findElement(By.id("btn1")).click();
+
+        String expectedErrorMessage;
 
         // Unlike other application servers, WebSphere Liberty Profile 16 & WebSphere traditional 9 wraps an unexpected exception of ServletException.
         // So the expected error page is different.
-        // confirms that 404 error occurred after login transition
-        if (apServerName == ApServerName.WEBSPHERELP && "16".equals(apServerVersion)
-                || apServerName == ApServerName.WEBSPHERETR && "9".equals(apServerVersion)) {
-            assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
-                    is("System Error..."));
+        if (apServerName == ApServerName.WEBSPHERELP || apServerName == ApServerName.WEBSPHERETR) {
+        	expectedErrorMessage = "System Error...";
         } else {
-            assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
-                    is("Page Not Found"));
+        	expectedErrorMessage = "Page Not Found";
         }
+
+        // confirms that 404 error occurred after login transition
+        assertThat(driver.findElement(By.xpath("/html/body/div/h2")).getText(),
+                is(expectedErrorMessage));
     }
 
     @Test

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/redirect/RedirectTest.java
@@ -89,7 +89,7 @@ public class RedirectTest extends FunctionTestSupport {
     @Test
     public void test01_03_redirectToExternalLink() {
 
-    	ApServerName apServerName = webDriverOperations.getApServerName();
+        ApServerName apServerName = webDriverOperations.getApServerName();
 
         driver.findElement(By.id("listWithExternalPath")).click();
         driver.findElement(By.id("btn1")).click();
@@ -107,13 +107,15 @@ public class RedirectTest extends FunctionTestSupport {
 
         driver.findElement(By.id("btn1")).click();
 
-        // Unlike other application servers, WebSphere Liberty Profile & WebSphere traditional wraps an unexpected exception of ServletException.
+        // Unlike other application servers, WebSphere Liberty Profile & WebSphere traditional wraps an unexpected exception of
+        // ServletException.
         // So the expected error page is different.
         String expectedErrorMessage;
-        if (apServerName == ApServerName.WEBSPHERELP || apServerName == ApServerName.WEBSPHERETR) {
-        	expectedErrorMessage = "System Error...";
+        if (apServerName == ApServerName.WEBSPHERELP
+                || apServerName == ApServerName.WEBSPHERETR) {
+            expectedErrorMessage = "System Error...";
         } else {
-        	expectedErrorMessage = "Page Not Found";
+            expectedErrorMessage = "Page Not Found";
         }
 
         // confirms that 404 error occurred after login transition

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
@@ -1,0 +1,15 @@
+package org.terasoluna.gfw.functionaltest.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Class that registers the value defined in application-env.properties of each profile in environment.
+ * <p>
+ * Passes application server information to WebDriver through JSP so that asserts can be changed for each application server.
+ * </p>
+ */
+@Configuration
+@PropertySource("classpath:/META-INF/spring/application-env.properties")
+public class PropertySourceConfig {
+}

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013-2017 NTT DATA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.terasoluna.gfw.functionaltest.config;
 
 import org.springframework.context.annotation.Configuration;

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -15,6 +15,8 @@
     <context:property-placeholder
         location="classpath*:/META-INF/spring/*.properties" />
 
+    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
+
     <bean class="org.dozer.spring.DozerBeanMapperFactoryBean">
         <property name="mappingFiles"
             value="classpath*:/META-INF/dozer/**/*-mapping.xml" />
@@ -102,7 +104,5 @@
         class="org.terasoluna.gfw.web.exception.ExceptionLoggingFilter">
         <property name="exceptionLogger" ref="variationExceptionLogger" />
     </bean>
-
-    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
 
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -103,4 +103,6 @@
         <property name="exceptionLogger" ref="variationExceptionLogger" />
     </bean>
 
+    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
+
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
@@ -26,6 +26,11 @@
     <tiles:insertAttribute name="header" />
     <tiles:insertAttribute name="body" />
     <hr>
+    <p align="right">
+        Application Server : 
+            <span id="apServerName"><spring:eval expression="@environment.getProperty('application.server.name')"/></span>
+            <span id="apServerVersion"><spring:eval expression="@environment.getProperty('application.server.version')"/></span>
+    </p>
     <p style="text-align: center; background: #e5eCf9;">
         <spring:message code="copyright" htmlEscape="false" />
         <span id="xtrack">(X-Track:${f:h(requestScope["X-Track"])})</span></p>


### PR DESCRIPTION
Please review #605 .
The contents of the 3 commits in this PR are as follows

----

#### Applied the mechanism
1st commit
I applied the mechanism of spring-functionaltest application (recognize application server) at c184140a3f801ac4874bccb907ff6a0dee494be9 commit.

2nd commit
As a result of applying the spring-functionaltest application mechanism, errors occured in `LoggingTest.java` of `test01_01_createDefaultXTrackMDC` and `test01_02_createCustomXTrackMDC`.
Those above errors are due to getting the AP server name instead of MDC as a result of trying to acquire MDC by using the p element.
So I changed the method of element(MDC) acquisition from p to id at 736a92a4f10a5f4f7167e259ef6e952761dd4eb0 commit.
I checked the [test item table page](https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/wiki/%5BWeb%5D-Test-case-design-of-Logging
) and confirmed that there was no problem with the above commit correction. 

----

#### Change assertion using the mechanism
3rd commit
I devide assertion whether application server is WAS or not in `RedirectTest.java` of `test01_03_redirectToExternalLink` at d901b03d13788a80256e7551d897e51a535353d3 commit.

----

#### test
I conducted the test under each 3 environments of local, tomcat8-postgresql9, webspherelp16-db2-11 and confirmed that no degradation occurred.