### PR TITLE
remove @ignore at ExceptionHandlingTest #605

### DIFF
--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/exceptionhandling/ExceptionHandlingTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/exceptionhandling/ExceptionHandlingTest.java
@@ -65,7 +65,6 @@ public class ExceptionHandlingTest extends FunctionTestSupport {
     }
 
     @Test
-    @Ignore("different result by ap server. does not work in weblogic.")
     public void test02_01_useCaseControllerHandling() {
 
         driver.findElement(By.id("useCaseControllerHandling_02_01")).click();


### PR DESCRIPTION
Please review #605 .

Remove ignore annotation at [ExceptionHandlingTest#test02_01_useCaseControllerHandling](https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/blob/master/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/exceptionhandling/ExceptionHandlingTest.java#L69).
At the time of #80 , because behavior of each AP server differently, Ignore annotation was attached.
However, at the present time, there is no differences among AP server.

Note:
This test case was ignored. Because it does not have to be tested with HttpStatusCode 100(Continue). (Currently tested with 4 HttpStatusCode from 200 to 500)
However, this does not mean that the test case of HttpStatusCode 100 is useless.