### PR TITLE
[1.0.x]recognize ap server #605

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/resin-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/resin-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=resin
+application.server.version=4

--- a/terasoluna-gfw-functionaltest-env/configs/resin-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/resin-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=resin
+application.server.version=4

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=tomcat
+application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=tomcat
+application.server.version=7

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=tomcat
+application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,3 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+application.server.name=weblogic
+application.server.version=12

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/application-env.properties
@@ -1,2 +1,6 @@
 app.redirect.allowed.externalUrl=http://terasolunaorg.github.io
-
+## application server name and version properties are used in order to
+## change the assertions in test which depends on application server.
+## when the new profile is added, set appropriate values.
+application.server.name=tomcat
+application.server.version=8.0

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -18,10 +18,9 @@ package org.terasoluna.gfw.functionaltest.app;
 /**
  * Enumeration class for identifying application server.
  * <p>
- * If application server name is not set in application-env.properties,
- * {@code UNKNOWN} is set.
+ * If application server name is not set in application-env.properties, {@code UNKNOWN} is set.
  * </p>
  */
 public enum ApServerName {
-	UNKNOWN, RESIN, TOMCAT, WEBLOGIC
+    UNKNOWN, RESIN, TOMCAT, WEBLOGIC
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -1,0 +1,12 @@
+package org.terasoluna.gfw.functionaltest.app;
+
+/**
+ * Enumeration class for identifying application server.
+ * <p>
+ * If application server name is not set in application.env.properties, <br/>
+ * UNKNOWN is set.
+ * </p>
+ */
+public enum ApServerName {
+	UNKNOWN, RESIN, TOMCAT, WEBLOGIC
+}

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/ApServerName.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2013-2017 NTT DATA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.terasoluna.gfw.functionaltest.app;
 
 /**
  * Enumeration class for identifying application server.
  * <p>
- * If application server name is not set in application.env.properties, <br/>
- * UNKNOWN is set.
+ * If application server name is not set in application-env.properties,
+ * {@code UNKNOWN} is set.
  * </p>
  */
 public enum ApServerName {

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -48,15 +48,6 @@ public class WebDriverOperations {
     }
 
     /**
-     * Get the text (display value) set for the specified element.
-     * @param by Identifier to look for elements
-     * @return And returns the text (display value)
-     */
-    public String getText(By by) {
-    	return webDriver.findElement(by).getText();
-    }
-
-    /**
      * Check the specified element exists.
      * @param by Identifier to look for elements
      * @return And returns true if the specified element is present.
@@ -95,7 +86,7 @@ public class WebDriverOperations {
      * @return application server name
      */
     public ApServerName getApServerName() {
-        String serverName = getText(By.id("apServerName")).toUpperCase();
+        String serverName = webDriver.findElement(By.id("apServerName")).getText().toUpperCase();
         try {
     	    return ApServerName.valueOf(serverName);
         } catch (IllegalArgumentException e) {
@@ -110,6 +101,6 @@ public class WebDriverOperations {
      * @return application server version
      */
     public String getApServerVersion() {
-    	return getText(By.id("apServerVersion"));
+        return webDriver.findElement(By.id("apServerVersion")).getText();
     }
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class that provides a (logic for WebDriver) browser operation.
@@ -29,6 +31,8 @@ public class WebDriverOperations {
     protected final WebDriver webDriver;
 
     protected long defaultTimeoutSecForImplicitlyWait = 5;
+
+    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
 
     public WebDriverOperations(WebDriver webDriver) {
         this.webDriver = webDriver;
@@ -41,6 +45,15 @@ public class WebDriverOperations {
     public void setDefaultTimeoutForImplicitlyWait(
             long defaultTimeoutSecForImplicitlyWait) {
         this.defaultTimeoutSecForImplicitlyWait = defaultTimeoutSecForImplicitlyWait;
+    }
+
+    /**
+     * Get the text (display value) set for the specified element.
+     * @param by Identifier to look for elements
+     * @return And returns the text (display value)
+     */
+    public String getText(By by) {
+    	return webDriver.findElement(by).getText();
     }
 
     /**
@@ -75,5 +88,28 @@ public class WebDriverOperations {
      */
     public void setTimeoutForImplicitlyWait(long timeout, TimeUnit timeUnit) {
         webDriver.manage().timeouts().implicitlyWait(timeout, timeUnit);
+    }
+
+    /**
+     * Get application server name.
+     * @return application server name
+     */
+    public ApServerName getApServerName() {
+        String serverName = getText(By.id("apServerName")).toUpperCase();
+        try {
+    	    return ApServerName.valueOf(serverName);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Unkown application server name:{} is detected.", serverName);
+            // If server name not defined in the ApServerName class, set it to UNKNOWN.
+            return ApServerName.UNKNOWN;
+        }
+    }
+
+    /**
+     * Get application server version.
+     * @return application server version
+     */
+    public String getApServerVersion() {
+    	return getText(By.id("apServerVersion"));
     }
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
  */
 public class WebDriverOperations {
 
+    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
+
     protected final WebDriver webDriver;
 
     protected long defaultTimeoutSecForImplicitlyWait = 5;
-
-    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
 
     public WebDriverOperations(WebDriver webDriver) {
         this.webDriver = webDriver;

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -28,7 +28,8 @@ import org.slf4j.LoggerFactory;
  */
 public class WebDriverOperations {
 
-    private static final Logger logger = LoggerFactory.getLogger(WebDriverOperations.class);
+    private static final Logger logger = LoggerFactory
+            .getLogger(WebDriverOperations.class);
 
     protected final WebDriver webDriver;
 
@@ -86,11 +87,13 @@ public class WebDriverOperations {
      * @return application server name
      */
     public ApServerName getApServerName() {
-        String serverName = webDriver.findElement(By.id("apServerName")).getText().toUpperCase();
+        String serverName = webDriver.findElement(By.id("apServerName"))
+                .getText().toUpperCase();
         try {
-    	    return ApServerName.valueOf(serverName);
+            return ApServerName.valueOf(serverName);
         } catch (IllegalArgumentException e) {
-            logger.warn("Unkown application server name:{} is detected.", serverName);
+            logger.warn("Unkown application server name:{} is detected.",
+                    serverName);
             // If server name not defined in the ApServerName class, set it to UNKNOWN.
             return ApServerName.UNKNOWN;
         }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/logging/LoggingTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/logging/LoggingTest.java
@@ -50,7 +50,7 @@ public class LoggingTest extends FunctionTestSupport {
 
         // cut x-Track MDC
         String targetMdc = driver.findElement(By.id("xTrackMDC")).getText();
-        String footerMdc = driver.findElement(By.cssSelector("p")).getText();
+        String footerMdc = driver.findElement(By.id("xtrack")).getText();
         footerMdc = footerMdc.substring(footerMdc.indexOf(":") + 1, footerMdc
                 .indexOf(":") + 33);
         // check default x-Track MDC
@@ -67,7 +67,7 @@ public class LoggingTest extends FunctionTestSupport {
 
         // cut x-Track MDC
         String targetMdc = driver.findElement(By.id("xTrackMDC")).getText();
-        String footerMdc = driver.findElement(By.cssSelector("p")).getText();
+        String footerMdc = driver.findElement(By.id("xtrack")).getText();
         footerMdc = footerMdc.substring(footerMdc.indexOf(":") + 1, footerMdc
                 .indexOf(":") + 33);
         // check custom x-Track MDC

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
@@ -1,0 +1,15 @@
+package org.terasoluna.gfw.functionaltest.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Class that registers the value defined in application-env.properties of each profile in environment.
+ * <p>
+ * Passes application server information to WebDriver through JSP so that asserts can be changed for each application server.
+ * </p>
+ */
+@Configuration
+@PropertySource("classpath:/META-INF/spring/application-env.properties")
+public class PropertySourceConfig {
+}

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/PropertySourceConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013-2017 NTT DATA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.terasoluna.gfw.functionaltest.config;
 
 import org.springframework.context.annotation.Configuration;

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -15,6 +15,8 @@
     <context:property-placeholder
         location="classpath*:/META-INF/spring/*.properties" />
 
+    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
+
     <bean class="org.dozer.spring.DozerBeanMapperFactoryBean">
         <property name="mappingFiles"
             value="classpath*:/META-INF/dozer/**/*-mapping.xml" />
@@ -102,7 +104,5 @@
         class="org.terasoluna.gfw.web.exception.ExceptionLoggingFilter">
         <property name="exceptionLogger" ref="variationExceptionLogger" />
     </bean>
-
-    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
 
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -103,4 +103,6 @@
         <property name="exceptionLogger" ref="variationExceptionLogger" />
     </bean>
 
+    <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
+
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
@@ -26,6 +26,11 @@
     <tiles:insertAttribute name="header" />
     <tiles:insertAttribute name="body" />
     <hr>
+    <p align="right">
+        Application Server : 
+            <span id="apServerName"><spring:eval expression="@environment.getProperty('application.server.name')"/></span>
+            <span id="apServerVersion"><spring:eval expression="@environment.getProperty('application.server.version')"/></span>
+    </p>
     <p style="text-align: center; background: #e5eCf9;">
         <spring:message code="copyright" htmlEscape="false" />
         (X-Track:${f:h(requestScope["X-Track"])})</p>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/layout/template.jsp
@@ -33,7 +33,7 @@
     </p>
     <p style="text-align: center; background: #e5eCf9;">
         <spring:message code="copyright" htmlEscape="false" />
-        (X-Track:${f:h(requestScope["X-Track"])})</p>
+        <span id="xtrack">(X-Track:${f:h(requestScope["X-Track"])})</span></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Please review #605 .
This PR is backport for 1.0.x .

In addition to `cherry-pick` , I add `<span id>` tag in template.jsp at 547a58b850db2ff0e1be7073858d683da0abd601 commit .
Because in 1.0.x branch , X-Track does not have `<span id>` tag .
I checked above change does not affect any test cases .