### PR TITLE
[5.3.x] add firefox version at .travis.yml #655

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
   - oraclejdk8
 addons:
   postgresql: "9.4"
+  firefox: "38.8.0esr"
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
(cherry picked from commit 4747e666e88e22d7144ad914ea3797a7135d03b7)

Please review #655 .
This PR is backport for 5.3.x .
