### PR TITLE
add Exception handling #740

### DIFF
--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WaitWebDriverEventListener.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WaitWebDriverEventListener.java
@@ -53,9 +53,14 @@ public class WaitWebDriverEventListener extends WebDriverEventListenerAdapter {
         } catch (TimeoutException e) {
             logger.debug("XTrack hasn't change in default time");
         }
-        wait.until((ExpectedCondition<Boolean>) wd -> ((JavascriptExecutor) wd)
-                .executeScript("return document.readyState").equals(
-                        "complete"));
+        try {
+            wait.until(
+                    (ExpectedCondition<Boolean>) wd -> ((JavascriptExecutor) wd)
+                            .executeScript("return document.readyState").equals(
+                                    "complete"));
+        } catch (TimeoutException e) {
+            logger.debug("document.readyState hasn't change in default time");
+        }
     }
 
     @Override

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WaitWebDriverEventListener.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WaitWebDriverEventListener.java
@@ -53,6 +53,7 @@ public class WaitWebDriverEventListener extends WebDriverEventListenerAdapter {
         } catch (TimeoutException e) {
             logger.debug("XTrack hasn't change in default time");
         }
+        // Since want to perform this processing after the above processing is completed, divide the try-catch.
         try {
             wait.until(
                     (ExpectedCondition<Boolean>) wd -> ((JavascriptExecutor) wd)


### PR DESCRIPTION
Please review #740 .

Because exception handling was not applied to wait.until (), 
problem occurred when TimeoutException occurred.
Therefore, implemented exception handling.

