### PR TITLE
[5.4.x] resolve deprecated api #788

### DIFF
--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/PageSource.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/PageSource.java
@@ -17,6 +17,7 @@ package org.terasoluna.gfw.functionaltest.app;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
@@ -69,8 +70,7 @@ public class PageSource {
 
         try {
             FileUtils.writeStringToFile(pageSourceFile, webDriver
-                    .getPageSource());
-
+                    .getPageSource(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             logger.error(e.toString());
         }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/queryescape/QueryEscapeTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/queryescape/QueryEscapeTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.terasoluna.gfw.functionaltest.app.FunctionTestSupport;

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElMapOfSimpleValueDefaultTrimController.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElMapOfSimpleValueDefaultTrimController.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.functionaltest.app.el;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
@@ -45,21 +46,15 @@ public class ElMapOfSimpleValueDefaultTrimController {
 
     @ModelAttribute
     public MapForm setUpForm() {
-        MapForm mapForm = new MapForm(new LinkedHashMap<String, String>() {
-            {
-                put("a", "1");
-                put("b", "2");
-                put("c", "3");
-            }
-        }, new MapFormItem(new LinkedHashMap<String, String>() {
-            {
-                put("d", "4");
-                put("e", "5");
-                put("f", "6");
-            }
-        }));
-
-        return mapForm;
+        Map<String, String> mapA = new LinkedHashMap<String, String>();
+        mapA.put("a", "1");
+        mapA.put("b", "2");
+        mapA.put("c", "3");
+        Map<String, String> itemMapA = new LinkedHashMap<String, String>();
+        mapA.put("d", "4");
+        mapA.put("e", "5");
+        mapA.put("f", "6");
+        return new MapForm(mapA, new MapFormItem(itemMapA));
     }
 
     @RequestMapping(value = "6_17", method = RequestMethod.GET)

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/message/MessageController.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/message/MessageController.java
@@ -70,6 +70,7 @@ public class MessageController {
         return "message/default";
     }
 
+    @SuppressWarnings("deprecation")
     @RequestMapping(value = "1_5_1", method = RequestMethod.GET)
     public String defaultSpecified_01_05_01(Model model) {
 

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/pagination/PaginationController.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/pagination/PaginationController.java
@@ -413,8 +413,8 @@ public class PaginationController {
     public String fuinctionTest_14_1_confirm(@PathVariable("page") int page,
             @PathVariable("size") int size, Model model) {
 
-        Page<Person> namePage = paginationService.findPerson(PageRequest.of(
-                page, size));
+        Page<Person> namePage = paginationService.findPerson(
+                new PageRequest(page, size));
 
         model.addAttribute("page", namePage);
 

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/pagination/PaginationController.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/pagination/PaginationController.java
@@ -413,8 +413,8 @@ public class PaginationController {
     public String fuinctionTest_14_1_confirm(@PathVariable("page") int page,
             @PathVariable("size") int size, Model model) {
 
-        Page<Person> namePage = paginationService.findPerson(
-                new PageRequest(page, size));
+        Page<Person> namePage = paginationService.findPerson(PageRequest.of(
+                page, size));
 
         model.addAttribute("page", namePage);
 

--- a/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/transactiontoken/TransactionTokenFlow1Controller.java
+++ b/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/transactiontoken/TransactionTokenFlow1Controller.java
@@ -56,6 +56,7 @@ public class TransactionTokenFlow1Controller {
         return "transactiontoken/flow1Step3";
     }
 
+    @SuppressWarnings("deprecation")
     @RequestMapping(value = "flow1", method = RequestMethod.POST, params = "intermediateWithFinish")
     @TransactionTokenCheck(type = TransactionTokenType.IN)
     public String flow1Step3_withFinish(


### PR DESCRIPTION
Please review #788 .
Cherry-picked from commit https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/commit/01cb002fac134c5ff08cfb07ceb2c8cc503268a0

The second commit is related to PageRequest.
In 5.4.x, `new PageRequest` is recommended API, so it was restored.