### PR TITLE
fix logback settings #837

### DIFF
--- a/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/interstage11-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/jboss7-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat8-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat85-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat9-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat9-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat9-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat9-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat9-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat9-postgresql/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat9-postgresql/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat9-postgresql/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/weblogic-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/webotx-oracle/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/configs/webspherelp-db2/resources/logback.xml
@@ -93,26 +93,32 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.SQL"> -->
-  <!-- <level value="debug" /> -->
-  <!-- </logger> -->
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+  <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <level value="debug" />
+  </logger>
 
-  <!-- <logger name="org.hibernate.type.descriptor.sql.BasicBinder"> -->
-  <!-- <level value="trace" /> -->
-  <!-- </logger> -->
+  <logger name="java.sql.Connection">
+    <level value="trace" />
+  </logger>
 
+  <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/logback.xml
@@ -104,14 +104,6 @@
     <level value="debug" />
   </logger>
 
-  <logger name="java.sql.Connection">
-    <level value="trace" />
-  </logger>
-
-  <logger name="java.sql.PreparedStatement">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.hibernate.SQL" additivity="true">
     <level value="debug" />
   </logger>

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/logback.xml
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/logback.xml
@@ -93,24 +93,13 @@
     <level value="info" />
   </logger>
 
-  <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
   </logger>
 
-  <logger name="jdbc.sqltiming">
-    <level value="debug" />
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
   </logger>
-
-  <logger name="org.springframework.jdbc.datasource">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.orm.jpa">
-    <level value="debug" />
-  </logger>
-  <logger name="org.springframework.transaction">
-    <level value="debug" />
-  </logger>
-
   <logger name="org.springframework.jdbc.datasource.DataSourceTransactionManager">
     <level value="debug" />
   </logger>
@@ -120,6 +109,16 @@
   </logger>
 
   <logger name="java.sql.PreparedStatement">
+    <level value="debug" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
+  <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>
 


### PR DESCRIPTION
Please review #837.

See https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/issues/837#issuecomment-591774990

* add settings
  * org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
  * org.springframework.jdbc.core.JdbcTemplate
  * org.hibernate.SQL
  * org.hibernate.type
  
* remove settings
  * org.springframework.jdbc.datasource
  * org.springframework.orm.jpa
  * org.springframework.transaction
  * jdbc.sqltiming (forget to erase)

It is determined that there is no problem because the logs output with the excluded settings are as follows.
(`org.springframework.transaction` is not logged in test execution)

``` java

level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Found thread-bound EntityManager [SessionImpl(2063178510<open>)] for JPA transaction
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Creating new transaction with name [org.terasoluna.gfw.functionaltest.domain.service.redirect.RedirectServiceImpl.findOne]: PROPAGATION_REQUIRED,ISOLATION_DEFAULT,readOnly; 'jpaTransactionManager'
level:DEBUG	logger:o.s.jdbc.datasource.DataSourceUtils             	message:Setting JDBC Connection [113732585, URL=jdbc:h2:mem:terasoluna-gfw-functionaltest, UserName=SA, H2 JDBC Driver] read-only
level:DEBUG	logger:o.h.engine.transaction.internal.TransactionImpl 	message:On TransactionImpl creation, JpaCompliance#isJpaTransactionComplianceEnabled == false
level:DEBUG	logger:o.h.engine.transaction.internal.TransactionImpl 	message:begin
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Exposing JPA transaction as JDBC [org.springframework.orm.jpa.vendor.HibernateJpaDialect$HibernateConnectionHandle@310717ed]
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Found thread-bound EntityManager [SessionImpl(2063178510<open>)] for JPA transaction
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Participating in existing transaction
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Initiating transaction commit
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Committing JPA transaction on EntityManager [SessionImpl(2063178510<open>)]
level:DEBUG	logger:o.h.engine.transaction.internal.TransactionImpl 	message:committing
level:DEBUG	logger:o.s.jdbc.datasource.DataSourceUtils             	message:Resetting read-only flag of JDBC Connection [113732585, URL=jdbc:h2:mem:terasoluna-gfw-functionaltest, UserName=SA, H2 JDBC Driver]
level:DEBUG	logger:o.springframework.orm.jpa.JpaTransactionManager 	message:Not closing pre-bound JPA EntityManager after transaction

```


<br>

Also, the configuration of logback.xml under `/configs` is different, so it should match `local`.
