### PR TITLE
fix logger name #852

### DIFF
--- a/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/domain/DBLogCleaner.java
+++ b/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/domain/DBLogCleaner.java
@@ -31,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class DBLogCleaner {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(
+    private static final Logger logger = LoggerFactory.getLogger(
             DBLogCleaner.class);
 
     private long savedPeriodMinutes = TimeUnit.MINUTES.toHours(24);
@@ -59,11 +59,11 @@ public class DBLogCleaner {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cleanupAll() {
-        LOGGER.info("Begin cleanupAll.");
+        logger.info("Begin cleanupAll.");
 
         cleanup(0L);
 
-        LOGGER.info("Finished cleanupAll.");
+        logger.info("Finished cleanupAll.");
     }
 
     private int cleanup(long savedPeriodMinutes) {
@@ -71,7 +71,7 @@ public class DBLogCleaner {
         Date cutoffDate = new Date(System.currentTimeMillis()
                 - (TimeUnit.MINUTES.toMillis(savedPeriodMinutes)));
 
-        LOGGER.info("Begin cleanup. cutoffDate is '{}'.", cutoffDate);
+        logger.info("Begin cleanup. cutoffDate is '{}'.", cutoffDate);
 
         // decide max event id of unnecessary log.
         MapSqlParameterSource queryParameters = new MapSqlParameterSource();
@@ -94,10 +94,10 @@ public class DBLogCleaner {
             deletedCount = namedParameterJdbcTemplate.update(
                     "DELETE FROM logging_event WHERE event_id <= :eventId",
                     deleteParameters);
-            LOGGER.info("Finished cleanup. Deleted log count is '{}'.",
+            logger.info("Finished cleanup. Deleted log count is '{}'.",
                     deletedCount);
         } else {
-            LOGGER.info("Finished cleanup. Not exists target log.");
+            logger.info("Finished cleanup. Not exists target log.");
         }
         return deletedCount;
     }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
@@ -39,7 +39,7 @@ import org.terasoluna.gfw.functionaltest.domain.DBLogCleaner;
 
 public class FunctionTestSupport extends ApplicationObjectSupport {
 
-    private static final Logger classLogger = LoggerFactory.getLogger(
+    private static final Logger logger = LoggerFactory.getLogger(
             FunctionTestSupport.class);
 
     protected static WebDriver driver;
@@ -231,7 +231,7 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
             try {
                 webDriver.quit();
             } catch (Throwable t) {
-                classLogger.error("failed quit.", t);
+                logger.error("failed quit.", t);
             }
         }
         webDrivers.clear();

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/transactiontoken/TransactionTokenTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/transactiontoken/TransactionTokenTest.java
@@ -36,6 +36,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.terasoluna.gfw.functionaltest.app.FunctionTestSupport;
@@ -45,6 +47,9 @@ import org.terasoluna.gfw.functionaltest.app.ScreenCaptureWebDriverEventListener
 @ContextConfiguration(locations = {
         "classpath:META-INF/spring/seleniumContext.xml" })
 public class TransactionTokenTest extends FunctionTestSupport {
+
+    private static final Logger logger = LoggerFactory.getLogger(
+            FunctionTestSupport.class);
 
     private static final Set<String> testCasesOfRebootTarget = new HashSet<String>(Arrays
             .asList("test03_01_defaultTokenStoreSizeOver",


### PR DESCRIPTION
Please review #852 .
Confirmed that the compilation was successful.

Since Logger object is not defined in [TransactionTokenTest.java](https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/blob/master/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/transactiontoken/TransactionTokenTest.java), the next dependent Logger object was referenced.
- https://github.com/spring-projects/spring-framework/blob/v5.2.3.RELEASE/spring-context/src/main/java/org/springframework/context/support/ApplicationObjectSupport.java#L52

Since the Logger object to be referenced is the one of FunctionTestSupport.java by correcting the object name, a compilation error occurs because it is private.

Defined because it is correct to define Logger object in TransactionTokenTest.java.
