### PR TITLE
support MS Edge, Headless Chrome, Headless Firefox.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <postgresql.version>42.2.9</postgresql.version>
     <ojdbc.version>19.3.0.0</ojdbc.version>
     <db2jcc4.version>4.21.29</db2jcc4.version>
-    <webdrivermanager.version>3.1.1</webdrivermanager.version>
+    <webdrivermanager.version>4.0.0</webdrivermanager.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <!-- == Project Properties == -->
     <project.env.main.directory>src/main</project.env.main.directory>

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/exceptionhandling/ExceptionHandlingTest.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/exceptionhandling/ExceptionHandlingTest.java
@@ -88,12 +88,12 @@ public class ExceptionHandlingTest extends FunctionTestSupport {
 
         driver.findElement(By.id("useCaseControllerHandling_02_01")).click();
 
+        // Some browsers may or may not display the screen.
+
         long retryTimes = 1L;
         if (driverType == WebDriverType.HTMLUNIT) {
-            // when HTTP Status 100 (Continue), the screen is not displayed and retry 4 times.
+            // HtmlUnit retry 4 times.
             retryTimes = 4L;
-        } else {
-            assertThat(driver.getTitle(), is("terasoluna-gfw-functionaltest"));
         }
 
         assertThat(dbLogProvider.countContainsMessageAndLevelsAndLogger(

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/ChromeDriverFactoryBean.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/ChromeDriverFactoryBean.java
@@ -16,11 +16,12 @@
 package org.terasoluna.gfw.functionaltest.app.webdrivers;
 
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 
 public class ChromeDriverFactoryBean extends
-                                     WebDriverManagerFactoryBean<ChromeDriver> {
+                                     HeadlessWebDriverManagerFactoryBean<ChromeDriver> {
 
     @Override
     public ChromeDriver getObject() {
@@ -28,6 +29,11 @@ public class ChromeDriverFactoryBean extends
             WebDriverManager.chromedriver().setup();
         }
 
+        if (headless) {
+            ChromeOptions options = new ChromeOptions();
+            options.setHeadless(headless);
+            return new ChromeDriver(options);
+        }
         return new ChromeDriver();
     }
 

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/EdgeDriverFactoryBean.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/EdgeDriverFactoryBean.java
@@ -15,19 +15,30 @@
  */
 package org.terasoluna.gfw.functionaltest.app.webdrivers;
 
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.edge.EdgeDriver;
 
-/**
- * Supported {@link WebDriver} types.
- */
-public enum WebDriverType {
-    FIREFOX, CHROME, EDGE, HTMLUNIT;
+import io.github.bonigarcia.wdm.WebDriverManager;
 
-    /**
-     * The default {@link WebDriver} type.
-     * @return {@link #FIREFOX}
-     */
-    public static WebDriverType DEFAULT() {
-        return FIREFOX;
+public class EdgeDriverFactoryBean extends
+                                   WebDriverManagerFactoryBean<EdgeDriver> {
+
+    @Override
+    public EdgeDriver getObject() {
+        if (System.getenv("webdriver.edge.driver") == null) {
+            WebDriverManager.edgedriver().setup();
+        }
+
+        return new EdgeDriver();
     }
+
+    @Override
+    public Class<?> getObjectType() {
+        return EdgeDriver.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return false;
+    }
+
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/FirefoxDriverFactoryBean.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/FirefoxDriverFactoryBean.java
@@ -22,7 +22,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 import io.github.bonigarcia.wdm.WebDriverManager;
 
 public class FirefoxDriverFactoryBean extends
-                                      WebDriverManagerFactoryBean<FirefoxDriver> {
+                                      HeadlessWebDriverManagerFactoryBean<FirefoxDriver> {
 
     @Override
     public FirefoxDriver getObject() {
@@ -35,6 +35,9 @@ public class FirefoxDriverFactoryBean extends
                 "ignore");
         profile.setPreference("network.proxy.type", 0);
         FirefoxOptions options = new FirefoxOptions().setProfile(profile);
+        if (headless) {
+            options.setHeadless(headless);
+        }
         return new FirefoxDriver(options);
     }
 

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/HeadlessWebDriverManagerFactoryBean.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/HeadlessWebDriverManagerFactoryBean.java
@@ -17,17 +17,14 @@ package org.terasoluna.gfw.functionaltest.app.webdrivers;
 
 import org.openqa.selenium.WebDriver;
 
-/**
- * Supported {@link WebDriver} types.
- */
-public enum WebDriverType {
-    FIREFOX, CHROME, EDGE, HTMLUNIT;
+public abstract class HeadlessWebDriverManagerFactoryBean<T extends WebDriver>
+                                                         extends
+                                                         WebDriverManagerFactoryBean<T> {
 
-    /**
-     * The default {@link WebDriver} type.
-     * @return {@link #FIREFOX}
-     */
-    public static WebDriverType DEFAULT() {
-        return FIREFOX;
+    protected boolean headless;
+
+    public void setHeadless(boolean headless) {
+        this.headless = headless;
     }
+
 }

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/WebDriverManagerFactoryBean.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/webdrivers/WebDriverManagerFactoryBean.java
@@ -34,7 +34,7 @@ public abstract class WebDriverManagerFactoryBean<T extends WebDriver>
     @Override
     public void afterPropertiesSet() throws Exception {
         if (propertyFileLocation != null) {
-            WebDriverManager.config().setProperties(propertyFileLocation);
+            WebDriverManager.globalConfig().setProperties(propertyFileLocation);
         }
     }
 

--- a/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/selenium.properties
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/selenium.properties
@@ -15,3 +15,6 @@ selenium.webDriverInputFieldAccessor=JAVASCRIPT
 
 # Allowable value is com.gargoylesoftware.htmlunit.BrowserVersion.*.
 selenium.htmlUnitBrowserVersion=FIREFOX_60
+
+# Supports headless browser.(Firefox, Chrome)
+selenium.headless=true

--- a/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/seleniumContext.xml
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/seleniumContext.xml
@@ -52,10 +52,18 @@
     <bean id="webDriver" class="org.terasoluna.gfw.functionaltest.app.webdrivers.FirefoxDriverFactoryBean"
       scope="prototype">
       <property name="propertyFileLocation" value="wdm.properties" />
+      <property name="headless" value="${selenium.headless}" />
     </bean>
   </beans>
   <beans profile="chrome">
     <bean id="webDriver" class="org.terasoluna.gfw.functionaltest.app.webdrivers.ChromeDriverFactoryBean"
+    scope="prototype">
+      <property name="propertyFileLocation" value="wdm.properties" />
+      <property name="headless" value="${selenium.headless}" />
+    </bean>
+  </beans>
+  <beans profile="edge">
+    <bean id="webDriver" class="org.terasoluna.gfw.functionaltest.app.webdrivers.EdgeDriverFactoryBean"
     scope="prototype">
       <property name="propertyFileLocation" value="wdm.properties" />
     </bean>


### PR DESCRIPTION
Please review #858 .

#### Spring profiles:
* `firefox`(default)
* `chrome`
* `edge` <- **new!**
* `htmlunit`

#### Properties:
* `selenium.headless` : **`true`(default)** -> if firefox|chrome, using headless browser.

#### Note:
* Headless browser does not display screen when HTTP status 100 is returned. I changed the test code because checking the screen is not mandatory.
* WebDriver.exe for Edge could not be acquired in Travis CI environment. The acquisition URL is determined by the OS, but it seems that the OS is not supported.