### PR TITLE
update the maven plugin #892

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,6 @@
     <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
     <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
     <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
-    <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <ojdbc.version>19.3.0.0</ojdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>sql-maven-plugin</artifactId>
-          <version>${org.codehaus.mojo.sql-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
           <version>${formatter-maven-plugin.version}</version>
@@ -181,7 +176,6 @@
   <properties>
     <!-- == Maven Plugin Versions == -->
     <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
-    <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
     <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
     <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,51 +52,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${org.codehaus.mojo.build-helper-maven-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>add-source</id>
-              <phase>generate-sources</phase>
-              <goals>
-                <goal>add-source</goal>
-              </goals>
-              <configuration>
-                <sources>
-                  <source>src/generated/java</source>
-                </sources>
-              </configuration>
-            </execution>
-            <execution>
-              <id>add-resource</id>
-              <phase>generate-resources</phase>
-              <goals>
-                <goal>add-resource</goal>
-              </goals>
-              <configuration>
-                <resources>
-                  <resource>
-                    <directory>src/generated/resources</directory>
-                  </resource>
-                </resources>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>${maven-war-plugin.version}</version>
           <configuration>
@@ -117,7 +72,6 @@
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
               </manifest>
             </archive>
-
           </configuration>
         </plugin>
         <plugin>
@@ -151,9 +105,9 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>com.google.code.maven-license-plugin</groupId>
-          <artifactId>maven-license-plugin</artifactId>
-          <version>${com.google.code.maven-license-plugin.version}</version>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/license/header.txt</header>
             <includes>
@@ -226,13 +180,11 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-war-plugin.version>2.5</maven-war-plugin.version>
-    <org.codehaus.mojo.build-helper-maven-plugin.version>1.9.1</org.codehaus.mojo.build-helper-maven-plugin.version>
+    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
     <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
-    <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
-    <formatter-maven-plugin.version>2.0.1</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
-    <com.google.code.maven-license-plugin.version>1.4.0</com.google.code.maven-license-plugin.version>
+    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
+    <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <ojdbc.version>19.3.0.0</ojdbc.version>
@@ -267,7 +219,7 @@
             </plugin>
             <plugin>
               <groupId>org.codehaus.cargo</groupId>
-              <artifactId>cargo-maven2-plugin</artifactId>
+              <artifactId>cargo-maven3-plugin</artifactId>
               <configuration>
                 <container>
                   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
     <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
     <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
     <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
+    <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <ojdbc.version>19.3.0.0</ojdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>${maven-war-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-war-plugin.version}</version>
           <configuration>
             <webResources>
               <resource>
@@ -77,7 +77,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>${formatter-maven-plugin.version}</version>
+          <version>${net.revelc.code.formatter.formatter-maven-plugin.version}</version>
           <configuration>
             <configFile>${project.root.basedir}/eclipse/formatter.xml
             </configFile>
@@ -94,7 +94,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>${xml-maven-plugin.version}</version>
+          <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
           <configuration>
             <indentSize>2</indentSize>
           </configuration>
@@ -102,7 +102,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>${license-maven-plugin.version}</version>
+          <version>${com.mycila.license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/license/header.txt</header>
             <includes>
@@ -175,10 +175,10 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
-    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <org.apache.maven.plugins.maven-war-plugin.version>3.3.1</org.apache.maven.plugins.maven-war-plugin.version>
+    <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
+    <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+    <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <ojdbc.version>19.3.0.0</ojdbc.version>

--- a/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -73,6 +73,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>sql-maven-plugin</artifactId>
+        <version>1.5</version>
         <dependencies>
           <dependency>
             <groupId>${db.groupId}</groupId>

--- a/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>terasoluna-gfw-functionaltest-initdb</artifactId>
 
   <properties>
+    <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
     <project.root.basedir>${project.parent.basedir}</project.root.basedir>
   </properties>
   <profiles>
@@ -73,7 +74,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>sql-maven-plugin</artifactId>
-        <version>1.5</version>
+        <version>${org.codehaus.mojo.sql-maven-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>${db.groupId}</groupId>

--- a/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>sql-maven-plugin</artifactId>
-        <version>${org.codehaus.mojo.sql-maven-plugin.version}</version>
+        <version>1.5</version>
         <dependencies>
           <dependency>
             <groupId>${db.groupId}</groupId>

--- a/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -13,7 +13,6 @@
   <artifactId>terasoluna-gfw-functionaltest-initdb</artifactId>
 
   <properties>
-    <org.codehaus.mojo.sql-maven-plugin.version>1.5</org.codehaus.mojo.sql-maven-plugin.version>
     <project.root.basedir>${project.parent.basedir}</project.root.basedir>
   </properties>
   <profiles>


### PR DESCRIPTION
Please review #892.

Confirmation is done with maven 3.8.1.

The changes other than the version upgrade are as follows:

- The `com.google.code:maven-license-plugin` has been changed to `com.mycila:license-maven-plugin` as in https://github.com/terasolunaorg/terasoluna-gfw/issues/600.
- The following plugins are not currently in use and have been removed.
  - maven-failsafe-plugin
  - build-helper-maven-plugin
- Changed the version setting of sql-maven-plugin to be described in initdb so that it is similar to multi-blank.
https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/893/commits/3bdcaf1e8dedd18b187685d9cd5e1b57292c079a
- Fixed the variable name of the plugin version to be `groupId.artifactId.pugin.version`.
https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/893/commits/89e2bfbe083ade039edd87ce07521955e15d40f9
- cargo-maven2-plugin has been renamed to cargo-maven3-plugin since 1.9.0
https://codehaus-cargo.github.io/cargo/Maven+3+Plugin.html