### PR TITLE
[5.6.x] Fixed the process of displaying the number of pages according to the guideline #923

### DIFF
--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/InOutElement.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/InOutElement.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" innerElement="span" outerElement="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/activeClass.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/activeClass.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" activeClass="actv" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/activeClassBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/activeClassBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" activeClass="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledClass.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledClass.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" disabledClass="dis" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledClassBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledClassBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" disabledClass="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledHref.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledHref.jsp
@@ -8,7 +8,7 @@
         });
     });
 </script>
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" disabledHref="#" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledHrefBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledHrefBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="page">
   <t:pagination page="${page}" disabledHref="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledPageLinkWithJavaScript.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/disabledPageLinkWithJavaScript.jsp
@@ -9,7 +9,7 @@
     });
 </script>
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" disabledHref="#" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/enableLinkOfCurrentPage.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/enableLinkOfCurrentPage.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" enableLinkOfCurrentPage="true" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLastLink.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLastLink.jsp
@@ -1,6 +1,6 @@
 <link rel="stylesheet"
   href="${pageContext.request.contextPath}/resources/vendor/bootstrap-3.0.0/css/bootstrap.css" />
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="text-center">
   <t:pagination page="${page}" firstLinkText="first" lastLinkText="last" previousLinkText=""
     nextLinkText="" outerElementClass="pagination" />

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLastLinkBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLastLinkBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" firstLinkText="" lastLinkText="" previousLinkText="" nextLinkText="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLinkText.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLinkText.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" firstLinkText="first" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLinkTextBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/firstLinkTextBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" firstLinkText="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/innerElement.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/innerElement.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" innerElement="div" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/innerElementClass.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/innerElementClass.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" innerElementClass="enable" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/lastLinkText.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/lastLinkText.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" lastLinkText="last" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/lastLinkTextBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/lastLinkTextBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" lastLinkText="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" maxDisplayCount="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountTwenty.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountTwenty.jsp
@@ -1,6 +1,6 @@
 <link rel="stylesheet"
   href="${pageContext.request.contextPath}/resources/vendor/bootstrap-3.0.0/css/bootstrap.css" />
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" maxDisplayCount="20" outerElementClass="pagination-sm" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountZero.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/maxDisplayCountZero.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" maxDisplayCount="0" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/nextLinkText.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/nextLinkText.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" nextLinkText="next" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/nextLinkTextBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/nextLinkTextBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" nextLinkText="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/outerElement.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/outerElement.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" outerElement="div" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/outerElementClass.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/outerElementClass.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" outerElementClass="rightPosition" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pager.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pager.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <t:pagination page="${page}" firstLinkText="" lastLinkText="" maxDisplayCount="0"
   nextLinkText="next" previousLinkText="prev" outerElementClass="pager" />
 <table class="maintable">

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pagination.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pagination.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pathQueryTmpl.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pathQueryTmpl.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}"
     pathTmpl="${pageContext.request.contextPath}/pagination/14_1/{page}/{size}" queryTmpl="" />

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pathtmpl.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/pathtmpl.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" pathTmpl="${pageContext.request.contextPath}/pagination/2_1" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/prevNextLink.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/prevNextLink.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" firstLinkText="" lastLinkText="" previousLinkText="prev"
     nextLinkText="next" />

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/previousLinkText.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/previousLinkText.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" previousLinkText="prev" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/previousLinkTextBlank.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/previousLinkTextBlank.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" previousLinkText="" />
 </div>

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/querytmpl.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/querytmpl.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}"
     queryTmpl="page={page}&size={size}&sort={sortOrderProperty},{sortOrderDirection}" />

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/search.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/search.jsp
@@ -12,7 +12,7 @@
 
 <c:if test="${not empty page and page.totalElements != 0}">
   <h2 class="center-content">
-    <span id="pagePosition">${f:h(page.number) + 1}</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
+    <span id="pagePosition">${f:h(page.number + 1) }</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
       id="rangeEnd">${(page.number * page.size) +
             page.numberOfElements}</span> / <span
       id="totalResults">${page.totalElements}</span> results )

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchPathTmplAndCriteriaQuery.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchPathTmplAndCriteriaQuery.jsp
@@ -12,7 +12,7 @@
 
 <c:if test="${not empty page and page.totalElements != 0}">
   <h2 class="center-content">
-    <span id="pagePosition">${f:h(page.number) + 1}</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
+    <span id="pagePosition">${f:h(page.number + 1) }</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
       id="rangeEnd">${(page.number * page.size) +
             page.numberOfElements}</span> / <span
       id="totalResults">${page.totalElements}</span> results )

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchPathTmplAndQueryTmplAndCriteriaQuery.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchPathTmplAndQueryTmplAndCriteriaQuery.jsp
@@ -12,7 +12,7 @@
 
 <c:if test="${not empty page and page.totalElements != 0}">
   <h2 class="center-content">
-    <span id="pagePosition">${f:h(page.number) + 1}</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
+    <span id="pagePosition">${f:h(page.number + 1) }</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
       id="rangeEnd">${(page.number * page.size) +
             page.numberOfElements}</span> / <span
       id="totalResults">${page.totalElements}</span> results )

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchQueryTmplAndCriteriaQuery.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/searchQueryTmplAndCriteriaQuery.jsp
@@ -12,7 +12,7 @@
 
 <c:if test="${not empty page and page.totalElements != 0}">
   <h2 class="center-content">
-    <span id="pagePosition">${f:h(page.number) + 1}</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
+    <span id="pagePosition">${f:h(page.number + 1) }</span> Page ( <span id="rangeStart">${(page.number * page.size) + 1}</span>-<span
       id="rangeEnd">${(page.number * page.size) +
             page.numberOfElements}</span> / <span
       id="totalResults">${page.totalElements}</span> results )

--- a/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/tagConfiguration.jsp
+++ b/terasoluna-gfw-functionaltest-web/src/main/webapp/WEB-INF/views/pagination/tagConfiguration.jsp
@@ -1,5 +1,5 @@
 
-<h1>${f:h(page.number) + 1}&nbsp;Page</h1>
+<h1>${f:h(page.number + 1) }&nbsp;Page</h1>
 <div class="pagination">
   <t:pagination page="${page}" firstLinkText="" previousLinkText="" nextLinkText="" lastLinkText=""
     maxDisplayCount="0" />


### PR DESCRIPTION
(cherry picked from commit 1d609673c3c8c063921e89b5fbca3fa54d476aef)

Please review #926

Confirmation method：
- I did a grep search with `(page.number)`and confirmed that there was no other part that needed correction.
- Confirm PaginationTest succeeds in local
-  Confirm PaginationTest succeeds in each environment(tomcat,jboss,weblogic) of GitLab
