### PR TITLE
fixed duration and logback-classic-db

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
       <dependency>
         <groupId>ch.qos.logback.db</groupId>
         <artifactId>logback-classic-db</artifactId>
-        <version>${logback-classic-db.version}</version>
+        <version>${logback-db.version}</version>
       </dependency>
       <!-- == End logback-db == -->
 
@@ -249,7 +249,7 @@
     <ojdbc.version>21.3.0.0</ojdbc.version>
     <db2jcc4.version>4.21.29</db2jcc4.version>
     <webdrivermanager.version>3.1.1</webdrivermanager.version>
-    <logback-classic-db.version>1.2.11.1</logback-classic-db.version>
+    <logback-db.version>1.2.11.1</logback-db.version>
     <!-- == Project Properties == -->
     <project.env.main.directory>src/main</project.env.main.directory>
     <project.env.buildFinalName>${project.artifactId}-${project.version}</project.env.buildFinalName>

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
@@ -195,13 +195,13 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
             driver = newWebDriver();
         }
         driver.manage().timeouts().implicitlyWait(
-                defaultTimeoutSecForImplicitlyWait);
+                this.defaultTimeoutSecForImplicitlyWait);
         driver.get(getPackageRootUrl());
 
         this.webDriverOperations = new WebDriverOperations(driver);
         this.webDriverOperations.setDefaultTimeoutForImplicitlyWait(
-                defaultTimeoutSecForImplicitlyWait);
-        this.webDriverWait = new WebDriverWait(driver, defaultTimeoutSecForImplicitlyWait);
+                this.defaultTimeoutSecForImplicitlyWait);
+        this.webDriverWait = new WebDriverWait(driver, this.defaultTimeoutSecForImplicitlyWait);
     }
 
     private WebDriver newWebDriver() {

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/FunctionTestSupport.java
@@ -108,7 +108,7 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
 
     protected WebDriverInputFieldAccessor inputFieldAccessor = WebDriverInputFieldAccessor.JAVASCRIPT;
 
-    protected long defaultTimeoutSecForImplicitlyWait = 5;
+    protected Duration defaultTimeoutSecForImplicitlyWait;
 
     protected FunctionTestSupport() {
         this.simplePackageName = this.getClass().getPackage().getName()
@@ -120,6 +120,13 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
             String webDriverInputFieldAccessor) {
         this.inputFieldAccessor = WebDriverInputFieldAccessor.valueOf(
                 webDriverInputFieldAccessor.toUpperCase());
+    }
+
+    @Value("${selenium.defaultTimeoutSecForImplicitlyWait:5}")
+    public void setDefaultTimeoutSecForImplicitlyWait(
+            long defaultTimeoutSecForImplicitlyWait) {
+        this.defaultTimeoutSecForImplicitlyWait = Duration.ofSeconds(
+                defaultTimeoutSecForImplicitlyWait);
     }
 
     @AfterClass
@@ -187,15 +194,14 @@ public class FunctionTestSupport extends ApplicationObjectSupport {
         if (driver == null) {
             driver = newWebDriver();
         }
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(
-                defaultTimeoutSecForImplicitlyWait));
+        driver.manage().timeouts().implicitlyWait(
+                defaultTimeoutSecForImplicitlyWait);
         driver.get(getPackageRootUrl());
 
         this.webDriverOperations = new WebDriverOperations(driver);
         this.webDriverOperations.setDefaultTimeoutForImplicitlyWait(
                 defaultTimeoutSecForImplicitlyWait);
-        this.webDriverWait = new WebDriverWait(driver, Duration.ofSeconds(
-                defaultTimeoutSecForImplicitlyWait));
+        this.webDriverWait = new WebDriverWait(driver, defaultTimeoutSecForImplicitlyWait);
     }
 
     private WebDriver newWebDriver() {

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -33,7 +33,7 @@ public class WebDriverOperations {
 
     protected final WebDriver webDriver;
 
-    protected long defaultTimeoutSecForImplicitlyWait = 5;
+    protected Duration defaultTimeoutSecForImplicitlyWait;
 
     public WebDriverOperations(WebDriver webDriver) {
         this.webDriver = webDriver;
@@ -44,7 +44,7 @@ public class WebDriverOperations {
      * @param defaultTimeoutSecForImplicitlyWait The default timeout value of the waiting process to find the element (s)
      */
     public void setDefaultTimeoutForImplicitlyWait(
-            long defaultTimeoutSecForImplicitlyWait) {
+            Duration defaultTimeoutSecForImplicitlyWait) {
         this.defaultTimeoutSecForImplicitlyWait = defaultTimeoutSecForImplicitlyWait;
     }
 
@@ -55,7 +55,7 @@ public class WebDriverOperations {
      */
     public boolean exists(By by) {
         webDriver.findElement(By.tagName("body"));
-        setTimeoutForImplicitlyWait(Duration.ofSeconds(0));
+        setTimeoutForImplicitlyWait(Duration.ZERO);
         boolean existsElement = true;
         try {
             webDriver.findElement(by).getText();
@@ -71,7 +71,7 @@ public class WebDriverOperations {
      * Set to the default value of the timeout value waiting process to find the element.
      */
     public void setDefaultTimeoutForImplicitlyWait() {
-        setTimeoutForImplicitlyWait(Duration.ofSeconds(defaultTimeoutSecForImplicitlyWait));
+        setTimeoutForImplicitlyWait(defaultTimeoutSecForImplicitlyWait);
     }
 
     /**

--- a/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/java/org/terasoluna/gfw/functionaltest/app/WebDriverOperations.java
@@ -71,7 +71,7 @@ public class WebDriverOperations {
      * Set to the default value of the timeout value waiting process to find the element.
      */
     public void setDefaultTimeoutForImplicitlyWait() {
-        setTimeoutForImplicitlyWait(defaultTimeoutSecForImplicitlyWait);
+        setTimeoutForImplicitlyWait(this.defaultTimeoutSecForImplicitlyWait);
     }
 
     /**

--- a/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/selenium.properties
+++ b/terasoluna-gfw-functionaltest-selenium/src/test/resources/META-INF/spring/selenium.properties
@@ -13,5 +13,8 @@ selenium.logDbPort=9192
 # JAVASCRIPT : for development and iteration testing.
 selenium.webDriverInputFieldAccessor=JAVASCRIPT
 
+# The default timeout value of the waiting process to find the element.
+selenium.defaultTimeoutSecForImplicitlyWait=5
+
 # Allowable value is com.gargoylesoftware.htmlunit.BrowserVersion.*.
 selenium.htmlUnitBrowserVersion=FIREFOX_60

--- a/terasoluna-gfw-functionaltest-web/pom.xml
+++ b/terasoluna-gfw-functionaltest-web/pom.xml
@@ -154,13 +154,6 @@
       <scope>test</scope>
     </dependency>
     <!-- == End Unit Test == -->
-
-    <!-- == Begin logback-db == -->
-    <dependency>
-      <groupId>ch.qos.logback.db</groupId>
-      <artifactId>logback-classic-db</artifactId>
-    </dependency>
-    <!-- == End logback-db == -->
   </dependencies>
   <properties>
     <project.root.basedir>${project.parent.basedir}</project.root.basedir>


### PR DESCRIPTION
Please review #981,#982
See https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/984#pullrequestreview-1072288500

relate to [TSF4J5-1301](https://terasolunaorg.atlassian.net/browse/TSF4J5-1301)([TSF4J5-1289](https://terasolunaorg.atlassian.net/browse/TSF4J5-1289)),[TSF4J5-1365](https://terasolunaorg.atlassian.net/browse/TSF4J5-1365),

https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/984#discussion_r945475729
16ad9f9d0a10b10f96c8e6a31e426eb18d66af96
Since `logback-classic-db` is defined by domain, it has been deleted from the web.

https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/984#discussion_r945468141
01cb6fd6091321d21e9ecd2e52918755fc0d26e6
Changed `logback-classic-db.version` to `logback-db.version`.

https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/984#discussion_r945470529
https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/pull/984#discussion_r945480961
a20f7a7c18f13432b4cbb129a57a352704932c3b
Changed to use `Duration.ZERO`.
`Duration.ofSeconds(defaultTimeoutSecForImplicitlyWait)` is cut out as a variable. Along with that, the value is cut out to the property file.