### PR TITLE
migrated dozer to mapstruct #988

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 evidence
 log
 *.iml
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,34 @@
   <build>
     <pluginManagement>
       <plugins>
+        <!--
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct-processor</artifactId>
+                <version>${mapstruct.version}</version>
+              </path>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </path>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-mapstruct-binding</artifactId>
+                <version>${lombok-mapstruct-binding.version}</version>
+              </path>
+            </annotationProcessorPaths>
+            <compilerArgs>
+              <arg>-Amapstruct.defaultComponentModel=spring</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+        -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -33,10 +33,6 @@
 
   <context:component-scan base-package="org.terasoluna.gfw.functionaltest.config" />
 
-  <bean class="com.github.dozermapper.spring.DozerBeanMapperFactoryBean">
-    <property name="mappingFiles" value="classpath*:/META-INF/dozer/**/*-mapping.xml" />
-  </bean>
-
   <!-- Message -->
   <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
     <property name="basenames">


### PR DESCRIPTION
Please review #988

In accordance with the blank project, the pom.xml contains the `maven-compiler-plugin` configuration, but it is commented out because MapStruct is not used.
