### PR TITLE
remove mvcHandlerMappingIntrospector #1021

### DIFF
--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-security.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-security.xml
@@ -47,8 +47,6 @@
       password="{pbkdf2}22dbc480b2444d53faa057ef10edcbb0f827c1618557fa72db09b71cf640c4ff21c14c6a80292dc5" /> <!-- the raw password is "user3" -->
   </sec:user-service>
 
-  <bean id="mvcHandlerMappingIntrospector" class="org.springframework.web.servlet.handler.HandlerMappingIntrospector" />
-
   <bean id="webexpressionHandler" class="org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler" />
 
 </beans>


### PR DESCRIPTION
Please review #1021 .
> Set `request-matcher="ant"` for all `sec:http` tags.

No fix required because it is defined in the existing source code.
https://github.com/terasolunaorg/terasoluna-gfw-functionaltest/blob/29d6aebda9772dbb83651477623d401bf209ccca/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-security.xml#L9