### PR TITLE
modified to specify dialect for each DB #1038

### DIFF
--- a/terasoluna-gfw-functionaltest-domain/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.xml
+++ b/terasoluna-gfw-functionaltest-domain/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.xml
@@ -11,6 +11,8 @@
     transaction-manager-ref="jpaTransactionManager" />
 
   <bean id="jpaVendorAdapter" class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter">
+    <!-- DatabasePlatform no longer needs to be specified since hibernate 6.0.10. https://github.com/spring-projects/spring-framework/commit/4c8f1910c82c340135082f3947f7dd9b611d6849-->
+    <property name="databasePlatform" value="${dialect}" />
     <property name="showSql" value="false" />
     <property name="database" value="${database}" />
   </bean>

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat10-oracle/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat10-oracle/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
@@ -1,1 +1,2 @@
 database=ORACLE
+dialect=org.hibernate.dialect.Oracle12cDialect

--- a/terasoluna-gfw-functionaltest-env/configs/tomcat10-postgresql/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
+++ b/terasoluna-gfw-functionaltest-env/configs/tomcat10-postgresql/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
@@ -1,1 +1,2 @@
 database=POSTGRESQL
+dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
+++ b/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-infra.properties
@@ -8,3 +8,4 @@ cp.maxActive=96
 cp.maxIdle=16
 cp.minIdle=0
 cp.maxWait=60000
+dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Please review #1038 

When using PostgreSQL, the dialect class used for `HibernateJpaVendorAdapter` is `org.hibernate.dialect.PostgreSQL95Dialect`, which has been removed since hibernate 6.2.
This problem has been fixed in the following commit, so we will revert this fix the next time we upgrade the Spring Boot version and see if it works.

https://github.com/spring-projects/spring-framework/commit/4c8f1910c82c340135082f3947f7dd9b611d6849