### PR TITLE
Added aop:aspectj-autoproxy according to JavaConfig definition. #1042

### DIFF
--- a/terasoluna-gfw-functionaltest-domain/src/test/resources/test-context.xml
+++ b/terasoluna-gfw-functionaltest-domain/src/test/resources/test-context.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
   <import resource="classpath:META-INF/spring/domain.xml" />
 
   <bean class="org.springframework.jdbc.core.JdbcTemplate">
     <property name="dataSource" ref="dataSource" />
   </bean>
+
+  <aop:aspectj-autoproxy />
+
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -110,4 +110,6 @@
     <property name="exceptionLogger" ref="variationExceptionLogger" />
   </bean>
 
+  <aop:aspectj-autoproxy />
+
 </beans>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-change-attribute.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-change-attribute.xml
@@ -37,6 +37,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="exceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-change-default-status-code.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-change-default-status-code.xml
@@ -42,6 +42,7 @@
     <property name="defaultStatusCode" value="400" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="exceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-exceptionlogger-variation.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-exceptionlogger-variation.xml
@@ -35,6 +35,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="changeCodeAndMessageExceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-ignore-result-messages.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-ignore-result-messages.xml
@@ -38,6 +38,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="exceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-log-format.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-log-format.xml
@@ -35,6 +35,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="changeFormatExceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-message-exception-coderesolver.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-message-exception-coderesolver.xml
@@ -35,6 +35,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="messageExceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-redirect.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc-exceptionhandling-redirect.xml
@@ -35,6 +35,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="exceptionLogger" />
   </bean>

--- a/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc.xml
+++ b/terasoluna-gfw-functionaltest-web/src/main/resources/META-INF/spring/spring-mvc.xml
@@ -41,6 +41,7 @@
     <property name="defaultStatusCode" value="500" />
   </bean>
   <!-- AOP. -->
+  <aop:aspectj-autoproxy />
   <bean id="handlerExceptionResolverLoggingInterceptor" class="org.terasoluna.gfw.web.exception.HandlerExceptionResolverLoggingInterceptor">
     <property name="exceptionLogger" ref="exceptionLogger" />
     <property name="ignoreExceptions">


### PR DESCRIPTION
Please review #1042 .

Added @EnableAspectJAutoProxy to enable AOP in JavaConfig version. So I added an equivalent definition to the XML as well.

JIRA
AOP definition exists and becomes the root of the definition file
Added aspectj-autoproxy to "applicationContext.xml, test-context.xml, springmvc.xml".
https://terasolunaorg.atlassian.net/browse/TSF4J5-3061