### PR TITLE
update boot to 3.2.0 #1053

### DIFF
--- a/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestDomainConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestDomainConfig.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.functionaltest.config.app;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -69,7 +70,7 @@ public class TerasolunaGfwFunctionaltestDomainConfig {
      */
     @Bean("resultMessagesLoggingInterceptor")
     public ResultMessagesLoggingInterceptor resultMessagesLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         ResultMessagesLoggingInterceptor bean = new ResultMessagesLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -83,7 +84,7 @@ public class TerasolunaGfwFunctionaltestDomainConfig {
      */
     @Bean("resultMessagesInfoLoggingInterceptor")
     public ResultMessagesInfoLoggingInterceptor resultMessagesInfoLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         ResultMessagesInfoLoggingInterceptor bean = new ResultMessagesInfoLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -97,7 +98,7 @@ public class TerasolunaGfwFunctionaltestDomainConfig {
      */
     @Bean
     public Advisor resultMessagesLoggingInterceptorAdvisor(
-            ResultMessagesLoggingInterceptor resultMessagesLoggingInterceptor) {
+            @Qualifier("resultMessagesLoggingInterceptor") ResultMessagesLoggingInterceptor resultMessagesLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "@within(org.springframework.stereotype.Service) && !@within(org.terasoluna.gfw.functionaltest.domain.exception.InfoLogging)");
@@ -112,7 +113,7 @@ public class TerasolunaGfwFunctionaltestDomainConfig {
      */
     @Bean
     public Advisor resultMessagesInfoLoggingInterceptorAdvisor(
-            ResultMessagesInfoLoggingInterceptor resultMessagesInfoLoggingInterceptor) {
+            @Qualifier("resultMessagesInfoLoggingInterceptor") ResultMessagesInfoLoggingInterceptor resultMessagesInfoLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "@within(org.terasoluna.gfw.functionaltest.domain.exception.InfoLogging)");

--- a/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestInfraConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestInfraConfig.java
@@ -27,6 +27,7 @@ import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -87,7 +88,7 @@ public class TerasolunaGfwFunctionaltestInfraConfig implements
      */
     @Bean("entityManagerFactory")
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
 
         LocalContainerEntityManagerFactoryBean bean = TerasolunaGfwFunctionaltestEnvConfig
                 .abstractEntityManagerFactory();
@@ -117,7 +118,8 @@ public class TerasolunaGfwFunctionaltestInfraConfig implements
      * @return Bean of configured {@link NamedParameterJdbcTemplate}
      */
     @Bean("jdbcTemplate")
-    public NamedParameterJdbcTemplate jdbcTemplate(DataSource dataSource) {
+    public NamedParameterJdbcTemplate jdbcTemplate(
+            @Qualifier("dataSource") DataSource dataSource) {
         NamedParameterJdbcTemplate bean = new NamedParameterJdbcTemplate(dataSource);
         return bean;
     }
@@ -143,7 +145,8 @@ public class TerasolunaGfwFunctionaltestInfraConfig implements
      * @return Bean of configured {@link SqlSessionFactoryBean}
      */
     @Bean("sqlSessionFactory")
-    public SqlSessionFactoryBean sqlSessionFactory(DataSource dataSource) {
+    public SqlSessionFactoryBean sqlSessionFactory(
+            @Qualifier("dataSource") DataSource dataSource) {
         SqlSessionFactoryBean bean = new SqlSessionFactoryBean();
         bean.setDataSource(dataSource);
         bean.setConfiguration(MybatisConfig.configuration());

--- a/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestJodaConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestJodaConfig.java
@@ -17,6 +17,7 @@ package org.terasoluna.gfw.functionaltest.config.app;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.terasoluna.gfw.common.date.jodatime.DefaultJodaTimeDateFactory;
@@ -26,6 +27,7 @@ import org.terasoluna.gfw.common.date.jodatime.JdbcFixedJodaTimeDateFactory;
 /**
  * JodaTimeDateFactory configuration definition.
  */
+@SuppressWarnings("deprecation")
 @Configuration
 public class TerasolunaGfwFunctionaltestJodaConfig {
 
@@ -45,7 +47,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("jdbcFixedDateFactory")
     public JdbcFixedJodaTimeDateFactory jdbcFixedJodaTimeDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcFixedJodaTimeDateFactory factory = new JdbcFixedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setCurrentTimestampQuery(
@@ -60,7 +62,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("dbErrorJdbcFixedDateFactory")
     public JdbcFixedJodaTimeDateFactory dbErrorJdbcFixedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcFixedJodaTimeDateFactory factory = new JdbcFixedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setCurrentTimestampQuery(
@@ -75,7 +77,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("msecJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory msecJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(
@@ -90,7 +92,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("secJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory secJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(
@@ -105,7 +107,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("minuteJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory minuteJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(
@@ -120,7 +122,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("hourJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory hourJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(
@@ -135,7 +137,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("dayJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory dayJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(
@@ -150,7 +152,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("useCacheDayJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory useCacheDayJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setUseCache(true);
@@ -166,7 +168,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("noCacheJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory noCacheJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setUseCache(false);
@@ -182,7 +184,7 @@ public class TerasolunaGfwFunctionaltestJodaConfig {
      */
     @Bean("dbErrorJdbcAdjustedDateFactory")
     public JdbcAdjustedJodaTimeDateFactory dbErrorJdbcAdjustedDateFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustedJodaTimeDateFactory factory = new JdbcAdjustedJodaTimeDateFactory();
         factory.setDataSource(dataSource);
         factory.setAdjustedValueQuery(

--- a/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestJsr310Config.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-domain/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestJsr310Config.java
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoUnit;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.terasoluna.gfw.common.time.ConfigurableAdjustClockFactory;
@@ -89,7 +90,8 @@ public class TerasolunaGfwFunctionaltestJsr310Config {
      * @return Bean of configured {@link JdbcClockFactory}
      */
     @Bean("defaultJdbcClockFactory")
-    public JdbcClockFactory defaultJdbcClockFactory(DataSource dataSource) {
+    public JdbcClockFactory defaultJdbcClockFactory(
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcClockFactory factory = new JdbcClockFactory(dataSource, "SELECT now FROM system_date");
         return factory;
     }
@@ -101,7 +103,7 @@ public class TerasolunaGfwFunctionaltestJsr310Config {
      */
     @Bean("adjustJdbcClockFactory")
     public JdbcAdjustClockFactory adjustJdbcClockFactory(
-            DataSource dataSource) {
+            @Qualifier("dataSource") DataSource dataSource) {
         JdbcAdjustClockFactory factory = new JdbcAdjustClockFactory(dataSource, "SELECT diff FROM operation_date where operation_date_id='2'", ChronoUnit.SECONDS);
         return factory;
     }

--- a/JavaConfig/terasoluna-gfw-functionaltest-env/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestEnvConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-env/src/main/java/org/terasoluna/gfw/functionaltest/config/app/TerasolunaGfwFunctionaltestEnvConfig.java
@@ -16,6 +16,7 @@
 package org.terasoluna.gfw.functionaltest.config.app;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -121,7 +122,7 @@ public class TerasolunaGfwFunctionaltestEnvConfig {
         bean.setMaxTotal(maxActive);
         bean.setMaxIdle(maxIdle);
         bean.setMinIdle(minIdle);
-        bean.setMaxWaitMillis(maxWait);
+        bean.setMaxWait(Duration.ofMillis(maxWait));
         return bean;
     }
 

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/date/DateController.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/date/DateController.java
@@ -35,6 +35,7 @@ import org.terasoluna.gfw.functionaltest.domain.service.date.DateService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+@SuppressWarnings("deprecation")
 @Controller
 @RequestMapping(value = "date")
 public class DateController {

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElController.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElController.java
@@ -121,9 +121,9 @@ public class ElController {
     }
 
     @PostMapping(value = "output_05_04")
-    public String urlULink_InputDatas(String URLPath, String outputQueryParam,
+    public String urlULink_InputDatas(
+            @RequestParam("outputQueryParam") String outputQueryParam,
             Model model) {
-        model.addAttribute("URLPath", URLPath);
         model.addAttribute("outputQueryParam", outputQueryParam);
 
         return "el/linkUOutput";

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcConfig.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -54,7 +55,7 @@ public class SpringMvcConfig implements WebMvcConfigurer {
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -93,7 +94,7 @@ public class SpringMvcConfig implements WebMvcConfigurer {
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
 
@@ -112,7 +113,7 @@ public class SpringMvcConfig implements WebMvcConfigurer {
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingChangeAttributeConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingChangeAttributeConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingChangeAttributeConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -88,7 +89,7 @@ public class SpringMvcExceptionhandlingChangeAttributeConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -102,7 +103,7 @@ public class SpringMvcExceptionhandlingChangeAttributeConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingChangeDefaultStatusCodeConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingChangeDefaultStatusCodeConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingChangeDefaultStatusCodeConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -88,7 +89,7 @@ public class SpringMvcExceptionhandlingChangeDefaultStatusCodeConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -102,7 +103,7 @@ public class SpringMvcExceptionhandlingChangeDefaultStatusCodeConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingExceptionloggerVariationConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingExceptionloggerVariationConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingExceptionloggerVariationConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -86,7 +87,7 @@ public class SpringMvcExceptionhandlingExceptionloggerVariationConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger changeCodeAndMessageExceptionLogger) {
+            @Qualifier("changeCodeAndMessageExceptionLogger") ExceptionLogger changeCodeAndMessageExceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(changeCodeAndMessageExceptionLogger);
         return bean;
@@ -100,7 +101,7 @@ public class SpringMvcExceptionhandlingExceptionloggerVariationConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingIgnoreResultMessagesConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingIgnoreResultMessagesConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingIgnoreResultMessagesConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -87,7 +88,7 @@ public class SpringMvcExceptionhandlingIgnoreResultMessagesConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -101,7 +102,7 @@ public class SpringMvcExceptionhandlingIgnoreResultMessagesConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingLogFormatConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingLogFormatConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingLogFormatConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -86,7 +87,7 @@ public class SpringMvcExceptionhandlingLogFormatConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger changeFormatExceptionLogger) {
+            @Qualifier("changeFormatExceptionLogger") ExceptionLogger changeFormatExceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(changeFormatExceptionLogger);
         return bean;
@@ -100,7 +101,7 @@ public class SpringMvcExceptionhandlingLogFormatConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingMessageExceptionCoderesolverConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingMessageExceptionCoderesolverConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingMessageExceptionCoderesolverConfig implem
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -86,7 +87,7 @@ public class SpringMvcExceptionhandlingMessageExceptionCoderesolverConfig implem
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger messageExceptionLogger) {
+            @Qualifier("messageExceptionLogger") ExceptionLogger messageExceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(messageExceptionLogger);
         return bean;
@@ -100,7 +101,7 @@ public class SpringMvcExceptionhandlingMessageExceptionCoderesolverConfig implem
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingRedirectConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringMvcExceptionhandlingRedirectConfig.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -50,7 +51,7 @@ public class SpringMvcExceptionhandlingRedirectConfig implements
      */
     @Bean
     public SystemExceptionResolver systemExceptionResolver(
-            ExceptionCodeResolver exceptionCodeResolver) {
+            @Qualifier("exceptionCodeResolver") ExceptionCodeResolver exceptionCodeResolver) {
         SystemExceptionResolver bean = new SystemExceptionResolver();
         bean.setExceptionCodeResolver(exceptionCodeResolver);
         bean.setOrder(3);
@@ -86,7 +87,7 @@ public class SpringMvcExceptionhandlingRedirectConfig implements
      */
     @Bean("handlerExceptionResolverLoggingInterceptor")
     public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
-            ExceptionLogger exceptionLogger) {
+            @Qualifier("exceptionLogger") ExceptionLogger exceptionLogger) {
         HandlerExceptionResolverLoggingInterceptor bean = new HandlerExceptionResolverLoggingInterceptor();
         bean.setExceptionLogger(exceptionLogger);
         return bean;
@@ -100,7 +101,7 @@ public class SpringMvcExceptionhandlingRedirectConfig implements
      */
     @Bean
     public Advisor handlerExceptionResolverLoggingInterceptorAdvisor(
-            HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
+            @Qualifier("handlerExceptionResolverLoggingInterceptor") HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor) {
         AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
         pointcut.setExpression(
                 "execution(* org.springframework.web.servlet.HandlerExceptionResolver.resolveException(..))");

--- a/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringSecurityConfig.java
+++ b/JavaConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/config/web/SpringSecurityConfig.java
@@ -17,6 +17,7 @@ package org.terasoluna.gfw.functionaltest.config.web;
 
 import java.util.LinkedHashMap;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
@@ -100,7 +101,7 @@ public class SpringSecurityConfig {
      */
     @Bean
     public AuthenticationProvider authProvider(
-            PasswordEncoder passwordEncoder) {
+            @Qualifier("passwordEncoder") PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService());
         authProvider.setPasswordEncoder(passwordEncoder);

--- a/XmlConfig/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-env.xml
+++ b/XmlConfig/terasoluna-gfw-functionaltest-env/src/main/resources/META-INF/spring/terasoluna-gfw-functionaltest-env.xml
@@ -19,7 +19,11 @@
     <property name="maxTotal" value="${cp.maxActive}" />
     <property name="maxIdle" value="${cp.maxIdle}" />
     <property name="minIdle" value="${cp.minIdle}" />
-    <property name="maxWaitMillis" value="${cp.maxWait}" />
+    <property name="maxWait" >
+      <bean class="java.time.Duration" factory-method="ofMillis">
+        <constructor-arg value="${cp.maxWait}" />
+      </bean>
+    </property>
   </bean>
 
   <bean id="integerSeq" class="org.terasoluna.gfw.common.sequencer.JdbcSequencer">

--- a/XmlConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/date/DateController.java
+++ b/XmlConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/date/DateController.java
@@ -35,6 +35,7 @@ import org.terasoluna.gfw.functionaltest.domain.service.date.DateService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+@SuppressWarnings("deprecation")
 @Controller
 @RequestMapping(value = "date")
 public class DateController {

--- a/XmlConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElController.java
+++ b/XmlConfig/terasoluna-gfw-functionaltest-web/src/main/java/org/terasoluna/gfw/functionaltest/app/el/ElController.java
@@ -121,9 +121,9 @@ public class ElController {
     }
 
     @PostMapping(value = "output_05_04")
-    public String urlULink_InputDatas(String URLPath, String outputQueryParam,
+    public String urlULink_InputDatas(
+            @RequestParam("outputQueryParam") String outputQueryParam,
             Model model) {
-        model.addAttribute("URLPath", URLPath);
         model.addAttribute("outputQueryParam", outputQueryParam);
 
         return "el/linkUOutput";


### PR DESCRIPTION
Please review #1053 
related to https://terasolunaorg.atlassian.net/browse/TSF4J5-3811

- In JavaConfig, modified to use `@Qualifier` to specify the name of a bean when a bean with the same type exists in the definition.
- Modified to make the name explicit when using `@RequestParam`.
- Deprecated methods fixed.
- `@SuppressWarnings` was given to classes using JodaTime.