### PR TITLE
update the plugin version #1144

### DIFF
--- a/JavaConfig/pom.xml
+++ b/JavaConfig/pom.xml
@@ -60,6 +60,7 @@
         </repository>
     </repositories>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -96,9 +97,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${org.apache.maven.plugins.maven-surefire-plugin.version}</version>
                     <configuration>
-                        <systemProperties>
+                        <systemPropertyVariables>
                             <jdk.tls.client.protocols>TLSv1.2</jdk.tls.client.protocols>
-                        </systemProperties>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -149,21 +150,12 @@
                                 </excludes>
                             </resource>
                         </webResources>
-                        <warName>${project.artifactId}</warName>
                         <archive>
                             <addMavenDescriptor>false</addMavenDescriptor>
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
                         </archive>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
-                    <configuration>
-                        <indentSize>2</indentSize>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -228,11 +220,10 @@
     </dependencyManagement>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <org.apache.maven.plugins.maven-war-plugin.version>3.3.2</org.apache.maven.plugins.maven-war-plugin.version>
-        <org.codehaus.mojo.build-helper-maven-plugin.version>3.3.0</org.codehaus.mojo.build-helper-maven-plugin.version>
-        <org.apache.maven.plugins.maven-failsafe-plugin.version>3.0.0-M7</org.apache.maven.plugins.maven-failsafe-plugin.version>
-        <org.apache.maven.plugins.maven-surefire-plugin.version>3.0.0-M7</org.apache.maven.plugins.maven-surefire-plugin.version>
-        <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+        <org.apache.maven.plugins.maven-war-plugin.version>3.4.0</org.apache.maven.plugins.maven-war-plugin.version>
+        <org.codehaus.mojo.build-helper-maven-plugin.version>3.6.0</org.codehaus.mojo.build-helper-maven-plugin.version>
+        <org.apache.maven.plugins.maven-failsafe-plugin.version>3.5.2</org.apache.maven.plugins.maven-failsafe-plugin.version>
+        <org.apache.maven.plugins.maven-surefire-plugin.version>3.5.2</org.apache.maven.plugins.maven-surefire-plugin.version>
         <!-- == Dependency Versions == -->
         <postgresql.version>42.7.1</postgresql.version>
         <ojdbc.version>23.3.0.23.09</ojdbc.version>

--- a/JavaConfig/terasoluna-gfw-functionaltest-env/pom.xml
+++ b/JavaConfig/terasoluna-gfw-functionaltest-env/pom.xml
@@ -48,21 +48,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>xml-maven-plugin</artifactId>
-                <configuration>
-                    <formatFileSets>
-                        <formatFileSet>
-                            <directory>${project.basedir}</directory>
-                            <includes>
-                                <include>configs/**/*.xml</include>
-                                <include>configs/**/*.xml.env.ftl</include>
-                            </includes>
-                        </formatFileSet>
-                    </formatFileSets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/JavaConfig/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/JavaConfig/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sql-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>${db.groupId}</groupId>

--- a/XmlConfig/pom.xml
+++ b/XmlConfig/pom.xml
@@ -60,6 +60,7 @@
         </repository>
     </repositories>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -96,9 +97,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${org.apache.maven.plugins.maven-surefire-plugin.version}</version>
                     <configuration>
-                        <systemProperties>
+                        <systemPropertyVariables>
                             <jdk.tls.client.protocols>TLSv1.2</jdk.tls.client.protocols>
-                        </systemProperties>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -149,21 +150,12 @@
                                 </excludes>
                             </resource>
                         </webResources>
-                        <warName>${project.artifactId}</warName>
                         <archive>
                             <addMavenDescriptor>false</addMavenDescriptor>
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
                         </archive>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
-                    <configuration>
-                        <indentSize>2</indentSize>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -228,11 +220,10 @@
     </dependencyManagement>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <org.apache.maven.plugins.maven-war-plugin.version>3.3.2</org.apache.maven.plugins.maven-war-plugin.version>
-        <org.codehaus.mojo.build-helper-maven-plugin.version>3.3.0</org.codehaus.mojo.build-helper-maven-plugin.version>
-        <org.apache.maven.plugins.maven-failsafe-plugin.version>3.0.0-M7</org.apache.maven.plugins.maven-failsafe-plugin.version>
-        <org.apache.maven.plugins.maven-surefire-plugin.version>3.0.0-M7</org.apache.maven.plugins.maven-surefire-plugin.version>
-        <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+        <org.apache.maven.plugins.maven-war-plugin.version>3.4.0</org.apache.maven.plugins.maven-war-plugin.version>
+        <org.codehaus.mojo.build-helper-maven-plugin.version>3.6.0</org.codehaus.mojo.build-helper-maven-plugin.version>
+        <org.apache.maven.plugins.maven-failsafe-plugin.version>3.5.2</org.apache.maven.plugins.maven-failsafe-plugin.version>
+        <org.apache.maven.plugins.maven-surefire-plugin.version>3.5.2</org.apache.maven.plugins.maven-surefire-plugin.version>
         <!-- == Dependency Versions == -->
         <postgresql.version>42.7.1</postgresql.version>
         <ojdbc.version>23.3.0.23.09</ojdbc.version>

--- a/XmlConfig/terasoluna-gfw-functionaltest-env/pom.xml
+++ b/XmlConfig/terasoluna-gfw-functionaltest-env/pom.xml
@@ -47,21 +47,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>xml-maven-plugin</artifactId>
-                <configuration>
-                    <formatFileSets>
-                        <formatFileSet>
-                            <directory>${project.basedir}</directory>
-                            <includes>
-                                <include>configs/**/*.xml</include>
-                                <include>configs/**/*.xml.env.ftl</include>
-                            </includes>
-                        </formatFileSet>
-                    </formatFileSets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <properties>

--- a/XmlConfig/terasoluna-gfw-functionaltest-initdb/pom.xml
+++ b/XmlConfig/terasoluna-gfw-functionaltest-initdb/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sql-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>${db.groupId}</groupId>


### PR DESCRIPTION
Please review #1144
- Fixed how to specify war generated by maven-war-plugin according to the documentation.
  https://maven.apache.org/plugins/maven-war-plugin/usage.html#invocation-of-war-exploded-goal
- The maven-surefire-plugin parameter `systemProperties` has been deprecated and replaced with `systemPropertyVariables`.
  https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#systemProperties
